### PR TITLE
Fix cmake wrappers to use relative path

### DIFF
--- a/contrib/libbacktrace-cmake/CMakeLists.txt
+++ b/contrib/libbacktrace-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LIBBACKTRACE_SRC ${CMAKE_SOURCE_DIR}/contrib/libbacktrace)
+set(LIBBACKTRACE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../libbacktrace)
 set(LIBBACKTRACE_BIN ${CMAKE_BINARY_DIR}/libbacktrace-generated)
 file(MAKE_DIRECTORY ${LIBBACKTRACE_BIN})
 

--- a/contrib/librseq-cmake/CMakeLists.txt
+++ b/contrib/librseq-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LIBRSEQ_SRC ${CMAKE_SOURCE_DIR}/contrib/librseq)
+set(LIBRSEQ_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../librseq)
 
 add_library(librseq STATIC
     ${LIBRSEQ_SRC}/src/rseq.c

--- a/contrib/liburing-cmake/CMakeLists.txt
+++ b/contrib/liburing-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LIBURING_SRC ${CMAKE_SOURCE_DIR}/contrib/liburing)
+set(LIBURING_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../liburing)
 set(LIBURING_BIN ${CMAKE_BINARY_DIR}/liburing-generated)
 
 file(MAKE_DIRECTORY ${LIBURING_BIN})


### PR DESCRIPTION
This change is needed to simplify consuming silk with its submodules.
This is not something that a production code will do, but can be useful for small projects.