### PR TITLE
Fix cancellation path in FiberScheduler/Sequencer

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1265,8 +1265,21 @@ void FiberScheduler::sleep(uint64_t nanoseconds, SleepFuture * future) noexcept
 
 void FiberScheduler::cancelSleep(SleepFuture * future) noexcept
 {
-    uint32_t prev = future->state.fetch_or(SleepFuture::CANCELLED, std::memory_order_acq_rel);
-    if (prev & SleepFuture::IN_TABLE)
+    uint32_t expected = future->state.load(std::memory_order_relaxed);
+    for (;;)
+    {
+        if (expected & SleepFuture::CANCELLED)
+        {
+            return;
+        }
+        if (future->state.compare_exchange_weak(
+                expected, expected | SleepFuture::CANCELLED, std::memory_order_acq_rel, std::memory_order_relaxed))
+        {
+            break;
+        }
+    }
+
+    if (expected & SleepFuture::IN_TABLE)
     {
         ProcessorState * processor = &scheduler->processorState[future->processorNumber];
         processor->cancelQueue.push(future);

--- a/src/fibers/sequencer.cpp
+++ b/src/fibers/sequencer.cpp
@@ -59,8 +59,21 @@ bool FiberSequencer::advance(uint64_t value) noexcept
 
 void FiberSequencer::cancelWait(Future * future) noexcept
 {
-    uint32_t prev = future->state.fetch_or(Future::CANCELLED, std::memory_order_acq_rel);
-    if (prev & Future::IN_TABLE)
+    uint32_t expected = future->state.load(std::memory_order_relaxed);
+    for (;;)
+    {
+        if (expected & Future::CANCELLED)
+        {
+            return;
+        }
+        if (future->state.compare_exchange_weak(
+                expected, expected | Future::CANCELLED, std::memory_order_acq_rel, std::memory_order_relaxed))
+        {
+            break;
+        }
+    }
+
+    if (expected & Future::IN_TABLE)
     {
         cancelQueue.push(future);
     }


### PR DESCRIPTION
A proper CAS is needed to prevent races. Should not be a problem for cancellation path.