### PR TITLE
Add FiberCondVar

### DIFF
--- a/include/silk/fibers/condvar.h
+++ b/include/silk/fibers/condvar.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <silk/fibers/future.h>
+#include <silk/util/list.h>
+#include <silk/util/spinlock.h>
+
+#include <cerrno>
+#include <cstdint>
+
+namespace silk
+{
+
+/**
+ * Fiber-aware condition variable.
+ *
+ * Mirrors std::condition_variable: a fiber atomically releases @p lock and
+ * suspends inside wait(); the lock is re-acquired before wait() returns.
+ * notify_one() wakes one currently waiting fiber and is a no-op if none is
+ * waiting; notify_all() wakes everyone currently waiting and has no effect
+ * on fibers that arrive later. Spurious wakeups are permitted by the standard
+ * and callers must re-check the protected predicate after wait() returns.
+ */
+class FiberCondVar
+{
+public:
+    /**
+     * Waiter handle. Inherits FiberFuture so callers can wait directly or
+     * compose with FiberFuture::waitForMultiple.
+     */
+    class Future : public FiberFuture
+    {
+    public:
+        /** Cancel a pending wait. Sets the future with ECANCELED if still pending. */
+        void cancel() noexcept
+        {
+            if (condVar)
+            {
+                condVar->cancelWait(this);
+            }
+        }
+
+    private:
+        friend class FiberCondVar;
+
+        ListEntry listEntry;
+        FiberCondVar * condVar = nullptr;
+        bool inWaiters = false;
+    };
+
+    /**
+     * Suspend the calling fiber until a notify wakes it. @p lock must be held
+     * on entry; it is released while the fiber is suspended and re-acquired
+     * before this function returns.
+     */
+    template <typename Lockable>
+    void wait(Lockable & lock) noexcept
+    {
+        Future future;
+        attach(&future);
+
+        lock.unlock();
+        future.wait();
+        lock.lock();
+    }
+
+    /**
+     * Suspend the calling fiber until a notify wakes it, or until @p nanoseconds
+     * elapses. @p lock must be held on entry; it is released while suspended and
+     * re-acquired before this function returns, whether the wakeup came from a
+     * notify or from the timeout.
+     *
+     * Returns 0 on a notify-driven wakeup or ETIMEDOUT on timeout. If a notify
+     * races with the timeout at the boundary the notification may be lost; the
+     * caller's predicate re-check (per the usual cv contract) handles that.
+     */
+    template <typename Lockable>
+    [[nodiscard]] int wait_for(Lockable & lock, uint64_t nanoseconds) noexcept
+    {
+        Future future;
+        attach(&future);
+
+        lock.unlock();
+
+        int r = FiberFuture::waitWithTimeout(&future, nanoseconds);
+        if (r == ETIMEDOUT)
+        {
+            future.cancel();
+            future.wait();
+        }
+
+        lock.lock();
+        return r;
+    }
+
+    /** Wake one currently waiting fiber. No-op if no fibers are waiting. */
+    void notify_one() noexcept;
+
+    /** Wake all currently waiting fibers. No effect on fibers that arrive later. */
+    void notify_all() noexcept;
+
+private:
+    using WaiterList = List<Future, &Future::listEntry>;
+
+    //
+    // Helpers.
+    //
+
+    void attach(Future * future) noexcept;
+    void cancelWait(Future * future) noexcept;
+
+    //
+    // State.
+    //
+
+    SpinLock spinLock;
+    WaiterList waiters;
+};
+
+} // namespace silk

--- a/include/silk/util/list.h
+++ b/include/silk/util/list.h
@@ -68,6 +68,9 @@ public:
         }
     }
 
+    /** Move all elements from @p other to the end of this list. O(1). @p other is left empty. */
+    void splice(List * other) noexcept { impl.splice(impl.end(), other->impl); }
+
     /** Return the next object after @p object, or nullptr if @p object is last. */
     T * next(T * object) noexcept
     {

--- a/src/fibers/benchmarks/condvar-bench.cpp
+++ b/src/fibers/benchmarks/condvar-bench.cpp
@@ -1,0 +1,247 @@
+#include <silk/fibers/condvar.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/mutex.h>
+#include <silk/util/assert.h>
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+
+namespace silk
+{
+
+class FiberCondVarBench : public benchmark::Fixture
+{
+};
+
+// Measures the uncontended fast path of notify_one(): the combiner enters,
+// finds the waiter list empty, and exits. The counter increment is the only
+// real work done. No waiter is ever registered.
+BENCHMARK_F(FiberCondVarBench, NotifyOneUncontended)(benchmark::State & state)
+{
+    struct Params
+    {
+        benchmark::State * state;
+        FiberCondVar * cv;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            for (auto _ : *p->state)
+            {
+                p->cv->notify_one();
+            }
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    int r = FiberScheduler::run(Params::fiberMain, {&state, &cv});
+    SILK_ASSERT(!r);
+}
+
+// Same as above for notify_all(): the sticky notifyAll flag is set, the
+// combiner observes an empty waiter list and clears the flag.
+BENCHMARK_F(FiberCondVarBench, NotifyAllUncontended)(benchmark::State & state)
+{
+    struct Params
+    {
+        benchmark::State * state;
+        FiberCondVar * cv;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            for (auto _ : *p->state)
+            {
+                p->cv->notify_all();
+            }
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    int r = FiberScheduler::run(Params::fiberMain, {&state, &cv});
+    SILK_ASSERT(!r);
+}
+
+// Producer/consumer ping-pong: a driver fiber publishes an item under the
+// mutex and notifies; a responder fiber waits, consumes the item, and signals
+// the driver to continue. Each iteration = two mutex round-trips + one
+// notify_one drain that wakes a waiter + one notify_one drain that exits empty
+// (the driver's wait sees the responder's "consumed" signal immediately).
+BENCHMARK_F(FiberCondVarBench, RoundTrip)(benchmark::State & state)
+{
+    struct Shared
+    {
+        FiberCondVar produced;
+        FiberCondVar consumed;
+        FiberMutex mutex;
+        int items = 0;
+        std::atomic<bool> stop{false};
+    };
+
+    struct Responder
+    {
+        Shared * shared;
+
+        static int fiberMain(Responder * p) noexcept
+        {
+            Shared * s = p->shared;
+            while (true)
+            {
+                s->mutex.lock();
+                while (s->items == 0 && !s->stop.load(std::memory_order_relaxed))
+                {
+                    s->produced.wait(s->mutex);
+                }
+                if (s->stop.load(std::memory_order_relaxed))
+                {
+                    s->mutex.unlock();
+                    return 0;
+                }
+                --s->items;
+                s->mutex.unlock();
+                s->consumed.notify_one();
+            }
+        }
+    };
+
+    struct Driver
+    {
+        benchmark::State * state;
+        Shared * shared;
+
+        static int fiberMain(Driver * p) noexcept
+        {
+            Shared * s = p->shared;
+            for (auto _ : *p->state)
+            {
+                s->mutex.lock();
+                ++s->items;
+                s->mutex.unlock();
+                s->produced.notify_one();
+
+                s->mutex.lock();
+                while (s->items != 0)
+                {
+                    s->consumed.wait(s->mutex);
+                }
+                s->mutex.unlock();
+            }
+            return 0;
+        }
+    };
+
+    Shared shared;
+    FiberFuture responder, driver;
+    int r = FiberScheduler::run(Responder::fiberMain, {&shared}, &responder);
+    SILK_ASSERT(!r);
+    r = FiberScheduler::run(Driver::fiberMain, {&state, &shared}, &driver);
+    SILK_ASSERT(!r);
+
+    driver.wait();
+
+    shared.mutex.lock();
+    shared.stop.store(true, std::memory_order_relaxed);
+    shared.mutex.unlock();
+    shared.produced.notify_one();
+    responder.wait();
+}
+
+// Broadcast wake-up cost: N waiter fibers suspend on cv.wait(); the driver
+// fires notify_all() and waits for every waiter to retire, then the cycle
+// repeats. Each iteration = N waiters suspending + one notify_all that wakes
+// them all + the driver re-checking the count.
+BENCHMARK_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
+{
+    static constexpr int N = 8;
+
+    struct Shared
+    {
+        FiberCondVar startSignal;
+        FiberCondVar doneSignal;
+        FiberMutex mutex;
+        int generation = 0;
+        int doneCount = 0;
+        std::atomic<bool> stop{false};
+    };
+
+    struct Waiter
+    {
+        Shared * shared;
+
+        static int fiberMain(Waiter * p) noexcept
+        {
+            Shared * s = p->shared;
+            int seen = 0;
+            while (true)
+            {
+                s->mutex.lock();
+                while (s->generation == seen && !s->stop.load(std::memory_order_relaxed))
+                {
+                    s->startSignal.wait(s->mutex);
+                }
+                if (s->stop.load(std::memory_order_relaxed))
+                {
+                    s->mutex.unlock();
+                    return 0;
+                }
+                seen = s->generation;
+                ++s->doneCount;
+                s->mutex.unlock();
+                s->doneSignal.notify_one();
+            }
+        }
+    };
+
+    struct Driver
+    {
+        benchmark::State * state;
+        Shared * shared;
+
+        static int fiberMain(Driver * p) noexcept
+        {
+            Shared * s = p->shared;
+            for (auto _ : *p->state)
+            {
+                s->mutex.lock();
+                s->doneCount = 0;
+                ++s->generation;
+                s->mutex.unlock();
+                s->startSignal.notify_all();
+
+                s->mutex.lock();
+                while (s->doneCount != N)
+                {
+                    s->doneSignal.wait(s->mutex);
+                }
+                s->mutex.unlock();
+            }
+            return 0;
+        }
+    };
+
+    Shared shared;
+    FiberFuture waiters[N], driver;
+    for (int i = 0; i < N; ++i)
+    {
+        int r = FiberScheduler::run(Waiter::fiberMain, {&shared}, &waiters[i]);
+        SILK_ASSERT(!r);
+    }
+    int r = FiberScheduler::run(Driver::fiberMain, {&state, &shared}, &driver);
+    SILK_ASSERT(!r);
+
+    driver.wait();
+
+    shared.mutex.lock();
+    shared.stop.store(true, std::memory_order_relaxed);
+    shared.mutex.unlock();
+    shared.startSignal.notify_all();
+
+    for (int i = 0; i < N; ++i)
+    {
+        waiters[i].wait();
+    }
+}
+
+} // namespace silk

--- a/src/fibers/condvar.cpp
+++ b/src/fibers/condvar.cpp
@@ -1,0 +1,75 @@
+#include <silk/fibers/condvar.h>
+
+#include <cerrno>
+
+namespace silk
+{
+
+void FiberCondVar::attach(Future * future) noexcept
+{
+    future->condVar = this;
+    future->inWaiters = true;
+
+    spinLock.lock();
+    waiters.push_back(future);
+    spinLock.unlock();
+}
+
+void FiberCondVar::notify_one() noexcept
+{
+    spinLock.lock();
+
+    Future * future = waiters.pop_front();
+    if (future)
+    {
+        future->inWaiters = false;
+    }
+
+    spinLock.unlock();
+
+    if (future)
+    {
+        future->set(0);
+    }
+}
+
+void FiberCondVar::notify_all() noexcept
+{
+    spinLock.lock();
+
+    WaiterList snapshot;
+    snapshot.splice(&waiters);
+
+    for (Future * future = snapshot.front(); future; future = snapshot.next(future))
+    {
+        future->inWaiters = false;
+    }
+
+    spinLock.unlock();
+
+    while (Future * future = snapshot.pop_front())
+    {
+        future->set(0);
+    }
+}
+
+void FiberCondVar::cancelWait(Future * future) noexcept
+{
+    spinLock.lock();
+
+    bool inWaiters = future->inWaiters;
+    if (inWaiters)
+    {
+        waiters.remove(future);
+        future->inWaiters = false;
+    }
+
+    spinLock.unlock();
+
+    if (inWaiters)
+    {
+        future->set(ECANCELED);
+    }
+}
+
+} // namespace silk

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1471,21 +1471,21 @@ void FiberScheduler::sleep(uint64_t nanoseconds, SleepFuture * future) noexcept
 
 void FiberScheduler::cancelSleep(SleepFuture * future) noexcept
 {
-    uint32_t expected = future->state.load(std::memory_order_relaxed);
+    uint32_t state = future->state.load(std::memory_order_relaxed);
     for (;;)
     {
-        if (expected & SleepFuture::CANCELLED)
+        if (state & SleepFuture::CANCELLED)
         {
             return;
         }
         if (future->state.compare_exchange_weak(
-                expected, expected | SleepFuture::CANCELLED, std::memory_order_acq_rel, std::memory_order_relaxed))
+                state, state | SleepFuture::CANCELLED, std::memory_order_acq_rel, std::memory_order_relaxed))
         {
             break;
         }
     }
 
-    if (expected & SleepFuture::IN_TABLE)
+    if (state & SleepFuture::IN_TABLE)
     {
         ProcessorState * processor = &scheduler->processorState[future->processorNumber];
         processor->cancelQueue.push(future);
@@ -1818,15 +1818,22 @@ __attribute__((noinline)) void FiberScheduler::handleSleepQueueSlow(ProcessorSta
     do
     {
         SleepFuture * next = SleepStack::next(sleepFuture);
-        uint32_t prev = sleepFuture->state.fetch_or(SleepFuture::IN_TABLE, std::memory_order_acq_rel);
-        if (prev & SleepFuture::CANCELLED)
+        uint32_t state = sleepFuture->state.load(std::memory_order_relaxed);
+        for (;;)
         {
-            sleepFuture->state.fetch_and(~SleepFuture::IN_TABLE, std::memory_order_relaxed);
-            sleepFuture->set(ECANCELED);
-        }
-        else
-        {
-            processor->sleepTree.insert(sleepFuture);
+            if (state & SleepFuture::CANCELLED)
+            {
+                sleepFuture->set(ECANCELED);
+                break;
+            }
+
+            SILK_ASSERT(!(state & SleepFuture::IN_TABLE));
+            if (sleepFuture->state.compare_exchange_weak(
+                    state, state | SleepFuture::IN_TABLE, std::memory_order_acq_rel, std::memory_order_relaxed))
+            {
+                processor->sleepTree.insert(sleepFuture);
+                break;
+            }
         }
         sleepFuture = next;
 
@@ -1848,17 +1855,21 @@ bool FiberScheduler::handleCancelQueue(ProcessorState * processor) noexcept
 
 __attribute__((noinline)) void FiberScheduler::handleCancelQueueSlow(ProcessorState * processor, SleepFuture * cancelEntry) noexcept
 {
+    uint64_t count = 0;
     do
     {
+        uint32_t prev = cancelEntry->state.fetch_and(~SleepFuture::IN_TABLE, std::memory_order_acq_rel);
+        SILK_ASSERT(prev & SleepFuture::IN_TABLE);
+
         SleepFuture * next = SleepStack::next(cancelEntry);
         processor->sleepTree.remove(cancelEntry);
-        cancelEntry->state.fetch_and(~SleepFuture::IN_TABLE, std::memory_order_relaxed);
         cancelEntry->set(ECANCELED);
         cancelEntry = next;
-
-        Perf::getSimpleCounter(simpleCounters[SLEEP_CANCELLED], processor->number).increment();
+        ++count;
 
     } while (cancelEntry);
+
+    Perf::getSimpleCounter(simpleCounters[SLEEP_CANCELLED], processor->number).increment(count);
 }
 
 bool FiberScheduler::handleExpiredWaiters(ProcessorState * processor) noexcept
@@ -1884,17 +1895,33 @@ bool FiberScheduler::handleExpiredWaiters(ProcessorState * processor) noexcept
 __attribute__((noinline)) void
 FiberScheduler::handleExpiredWaitersSlow(ProcessorState * processor, SleepFuture * sleepFuture, uint64_t now) noexcept
 {
+    uint64_t count = 0;
     do
     {
-        processor->sleepTree.remove(sleepFuture);
-        sleepFuture->state.fetch_and(~SleepFuture::IN_TABLE, std::memory_order_relaxed);
-        sleepFuture->set(0);
+        uint32_t state = sleepFuture->state.load(std::memory_order_relaxed);
+        for (;;)
+        {
+            if (state & SleepFuture::CANCELLED)
+            {
+                sleepFuture = processor->sleepTree.next(sleepFuture);
+                break;
+            }
 
-        Perf::getSimpleCounter(simpleCounters[SLEEP_EXPIRED], processor->number).increment();
-
-        sleepFuture = processor->sleepTree.min();
+            SILK_ASSERT(state & SleepFuture::IN_TABLE);
+            if (sleepFuture->state.compare_exchange_weak(
+                    state, state & ~SleepFuture::IN_TABLE, std::memory_order_acq_rel, std::memory_order_relaxed))
+            {
+                SleepFuture * next = processor->sleepTree.remove(sleepFuture);
+                sleepFuture->set(0);
+                sleepFuture = next;
+                ++count;
+                break;
+            }
+        }
 
     } while (sleepFuture && sleepFuture->deadlineCycles <= now);
+
+    Perf::getSimpleCounter(simpleCounters[SLEEP_EXPIRED], processor->number).increment(count);
 }
 
 void FiberScheduler::runFiber(Fiber * fiber, CpuTimer * timer) noexcept

--- a/src/fibers/future.cpp
+++ b/src/fibers/future.cpp
@@ -58,9 +58,6 @@ void FiberFuture::signal() noexcept
                 MultipleWaitState * waitState = reinterpret_cast<MultipleWaitState *>(currentState.waiter);
                 waitState->completionFuture->signal();
                 waitState->completionCounter.fetch_add(1, std::memory_order_release);
-
-                // TSan can't see happens-before through relaxed-spin + fence; annotate explicitly.
-                TSAN_RELEASE(waitState);
             }
             else if (currentState.hasCallback)
             {
@@ -193,11 +190,17 @@ uint64_t FiberFuture::waitForMultiple(FiberFuture ** futureArray, uint64_t futur
         {
             schedYield();
         }
-        std::atomic_thread_fence(std::memory_order_acquire);
-    }
 
-    // acquire side; pairs with TSAN_RELEASE in signal
-    TSAN_ACQUIRE(&waitState);
+#if defined(__SANITIZE_THREAD__)
+        // TSan does not track HB through a standalone acquire fence paired
+        // with relaxed loads. Do an extra acquire-load on the counter under
+        // TSan so the release-acquire pair on this atomic is directly visible
+        // to the tool.
+        waitState.completionCounter.load(std::memory_order_acquire);
+#else
+        std::atomic_thread_fence(std::memory_order_acquire);
+#endif
+    }
 
     return completionIndex;
 }

--- a/src/fibers/tests/condvar-test.cpp
+++ b/src/fibers/tests/condvar-test.cpp
@@ -1,0 +1,385 @@
+#include <silk/fibers/condvar.h>
+
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/fibers/mutex.h>
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+
+namespace silk
+{
+
+namespace
+{
+
+// After @p registered fires, block until the test fiber has called cv.wait()
+// and released the mutex. Locking + unlocking the mutex here proves the fiber
+// is past the unlock inside wait().
+void waitUntilSuspended(FiberMutex & mutex, FiberFuture & registered) noexcept
+{
+    registered.wait();
+    mutex.lock();
+    mutex.unlock();
+}
+
+} // namespace
+
+TEST(FiberCondVar, notifyOneWakesWaiter)
+{
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+        FiberFuture * registered;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            p->mutex->lock();
+            p->registered->set(0);
+            p->cv->wait(*p->mutex);
+            p->mutex->unlock();
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFuture, registered;
+    int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex, &registered}, &fiberFuture);
+    ASSERT_FALSE(r);
+
+    waitUntilSuspended(mutex, registered);
+
+    cv.notify_one();
+    fiberFuture.wait();
+}
+
+TEST(FiberCondVar, notifyAllWakesAll)
+{
+    static constexpr int N = 4;
+
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+        FiberFuture * registered;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            p->mutex->lock();
+            p->registered->set(0);
+            p->cv->wait(*p->mutex);
+            p->mutex->unlock();
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFutures[N], registered[N];
+
+    for (int i = 0; i < N; ++i)
+    {
+        int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex, &registered[i]}, &fiberFutures[i]);
+        ASSERT_FALSE(r);
+        waitUntilSuspended(mutex, registered[i]);
+    }
+
+    cv.notify_all();
+
+    for (int i = 0; i < N; ++i)
+    {
+        fiberFutures[i].wait();
+    }
+}
+
+TEST(FiberCondVar, notifyOneWakesOneAtATime)
+{
+    static constexpr int N = 4;
+
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+        FiberFuture * registered;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            p->mutex->lock();
+            p->registered->set(0);
+            p->cv->wait(*p->mutex);
+            p->mutex->unlock();
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFutures[N], registered[N];
+
+    for (int i = 0; i < N; ++i)
+    {
+        int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex, &registered[i]}, &fiberFutures[i]);
+        ASSERT_FALSE(r);
+        waitUntilSuspended(mutex, registered[i]);
+    }
+
+    for (int i = 0; i < N; ++i)
+    {
+        cv.notify_one();
+        fiberFutures[i].wait();
+    }
+}
+
+TEST(FiberCondVar, waitReacquiresMutex)
+{
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+        FiberFuture * registered;
+        FiberFuture * done;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            p->mutex->lock();
+            p->registered->set(0);
+            p->cv->wait(*p->mutex);
+            // Mutex must be re-held on return: unlocking proves it.
+            p->mutex->unlock();
+            p->done->set(0);
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFuture, registered, done;
+    int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex, &registered, &done}, &fiberFuture);
+    ASSERT_FALSE(r);
+
+    waitUntilSuspended(mutex, registered);
+
+    cv.notify_one();
+    done.wait();
+    fiberFuture.wait();
+}
+
+TEST(FiberCondVar, notifyOneNoWaiterNoCrash)
+{
+    FiberCondVar cv;
+    cv.notify_one();
+}
+
+TEST(FiberCondVar, notifyAllNoWaiterNoCrash)
+{
+    FiberCondVar cv;
+    cv.notify_all();
+}
+
+TEST(FiberCondVar, syncWaitWithStdUniqueLock)
+{
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+        FiberFuture * registered;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            std::unique_lock lock(*p->mutex);
+            p->registered->set(0);
+            p->cv->wait(lock);
+            return 0;
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFuture, registered;
+    int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex, &registered}, &fiberFuture);
+    ASSERT_FALSE(r);
+
+    waitUntilSuspended(mutex, registered);
+
+    cv.notify_one();
+    fiberFuture.wait();
+}
+
+TEST(FiberCondVar, waitForTimesOut)
+{
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            std::unique_lock lock(*p->mutex);
+            return p->cv->wait_for(lock, 10'000'000); // 10 ms
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFuture;
+    int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex}, &fiberFuture);
+    ASSERT_FALSE(r);
+    EXPECT_EQ(fiberFuture.wait(), ETIMEDOUT);
+}
+
+TEST(FiberCondVar, waitForNotifyBeforeTimeout)
+{
+    struct Params
+    {
+        FiberCondVar * cv;
+        FiberMutex * mutex;
+        FiberFuture * registered;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            std::unique_lock lock(*p->mutex);
+            p->registered->set(0);
+            return p->cv->wait_for(lock, 60'000'000'000ull); // 60 s
+        }
+    };
+
+    FiberCondVar cv;
+    FiberMutex mutex;
+    FiberFuture fiberFuture, registered;
+    int r = FiberScheduler::run(Params::fiberMain, {&cv, &mutex, &registered}, &fiberFuture);
+    ASSERT_FALSE(r);
+
+    waitUntilSuspended(mutex, registered);
+
+    cv.notify_one();
+    EXPECT_EQ(fiberFuture.wait(), 0);
+}
+
+TEST(FiberCondVar, predicateLoop)
+{
+    static constexpr int TOTAL = 16;
+
+    struct Shared
+    {
+        FiberCondVar cv;
+        FiberMutex mutex;
+        int produced = 0;
+        int consumed = 0;
+    };
+
+    struct ConsumerParams
+    {
+        Shared * shared;
+
+        static int fiberMain(ConsumerParams * p) noexcept
+        {
+            Shared * s = p->shared;
+            while (true)
+            {
+                std::unique_lock lock(s->mutex);
+                while (s->produced == s->consumed)
+                {
+                    s->cv.wait(lock);
+                }
+                ++s->consumed;
+                if (s->consumed == TOTAL)
+                {
+                    return 0;
+                }
+            }
+        }
+    };
+
+    Shared shared;
+    FiberFuture consumerDone;
+    int r = FiberScheduler::run(ConsumerParams::fiberMain, {&shared}, &consumerDone);
+    ASSERT_FALSE(r);
+
+    for (int i = 0; i < TOTAL; ++i)
+    {
+        {
+            std::unique_lock lock(shared.mutex);
+            ++shared.produced;
+        }
+        shared.cv.notify_one();
+    }
+
+    consumerDone.wait();
+    EXPECT_EQ(shared.consumed, TOTAL);
+}
+
+// Stress the cancel-vs-notify race: many waiters call wait_for with short
+// timeouts so most will hit the timeout path and self-cancel, while a producer
+// fiber hammers notify_all in parallel. Without the inWaiters flag this would
+// race on Future::listEntry (cancel removing from waiters while notify_all
+// iterates a splice into its own snapshot) — TSAN would catch it.
+TEST(FiberCondVar, waitForCancellationRace)
+{
+    static constexpr int N_WAITERS = 8;
+    static constexpr int ITERATIONS = 256;
+
+    struct Shared
+    {
+        FiberCondVar cv;
+        FiberMutex mutex;
+        std::atomic<int> completed{0};
+    };
+
+    struct WaiterParams
+    {
+        Shared * shared;
+
+        static int fiberMain(WaiterParams * p) noexcept
+        {
+            Shared * s = p->shared;
+            for (int i = 0; i < ITERATIONS; ++i)
+            {
+                std::unique_lock lock(s->mutex);
+                (void)s->cv.wait_for(lock, 1'000); // 1 us; usually times out
+            }
+            s->completed.fetch_add(1, std::memory_order_relaxed);
+            return 0;
+        }
+    };
+
+    struct NotifierParams
+    {
+        Shared * shared;
+
+        static int fiberMain(NotifierParams * p) noexcept
+        {
+            Shared * s = p->shared;
+            while (s->completed.load(std::memory_order_relaxed) < N_WAITERS)
+            {
+                s->cv.notify_all();
+                FiberScheduler::yield();
+            }
+            return 0;
+        }
+    };
+
+    Shared shared;
+    FiberFuture waiters[N_WAITERS];
+    FiberFuture notifier;
+
+    for (int i = 0; i < N_WAITERS; ++i)
+    {
+        int r = FiberScheduler::run(WaiterParams::fiberMain, {&shared}, &waiters[i]);
+        ASSERT_FALSE(r);
+    }
+    int r = FiberScheduler::run(NotifierParams::fiberMain, {&shared}, &notifier);
+    ASSERT_FALSE(r);
+
+    for (int i = 0; i < N_WAITERS; ++i)
+    {
+        waiters[i].wait();
+    }
+    notifier.wait();
+
+    EXPECT_EQ(shared.completed.load(), N_WAITERS);
+}
+
+} // namespace silk


### PR DESCRIPTION
Implements a fiber-aware condition variable with notify_one/notify_all semantics. wait() atomically releases the protecting lock and suspends, re-acquiring before return; wait_for() adds a nanosecond-bounded variant.