### PR TITLE
Fix data loss on cancelled io

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1438,7 +1438,6 @@ void FiberScheduler::poll(int fd, uint32_t events, uint64_t * triggeredEvents, I
 
 void FiberScheduler::cancelIo(IoFuture * future) noexcept
 {
-    future->result = nullptr;
     enqueueIo(
         nullptr,
         [=](io_uring_sqe * sqe) noexcept

--- a/src/fibers/tests/io-cancel-test.cpp
+++ b/src/fibers/tests/io-cancel-test.cpp
@@ -1,0 +1,81 @@
+#include <silk/fibers/fiber.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <unistd.h>
+
+namespace silk
+{
+
+// Repeatedly read then immediately cancel.
+// Make sure no data is lost.
+TEST(IoCancel, cancelMustNotDropDeliveredBytes)
+{
+    static constexpr uint64_t TOTAL = 4096;
+
+    struct Params
+    {
+        int readFd;
+        int writeFd;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            std::string expected(TOTAL, '\0');
+            for (uint64_t i = 0; i < TOTAL; ++i)
+            {
+                expected[i] = static_cast<char>(i & 0xFF);
+            }
+
+            EXPECT_EQ(::write(p->writeFd, expected.data(), TOTAL), static_cast<ssize_t>(TOTAL));
+            ::close(p->writeFd);
+
+            std::string got;
+            for (;;)
+            {
+                char buf[64] = {};
+                uint64_t bytes_read = 0;
+                FiberScheduler::IoFuture future;
+                iovec iov{buf, sizeof(buf)};
+                FiberScheduler::read(p->readFd, &iov, 1, 0, &bytes_read, &future);
+                future.cancel();
+                if (future.wait() == 0)
+                {
+                    // Read won (likely).
+                    if (bytes_read == 0)
+                    {
+                        break;
+                    }
+                    got.append(buf, bytes_read);
+                }
+                else
+                {
+                    // Cancel won.
+                    // It's unlikely to happen consistently,
+                    // but to keep the test independent of kernel internals, read to make progress.
+                    if (!FiberScheduler::read(p->readFd, buf, sizeof(buf), 0, &bytes_read))
+                    {
+                        if (bytes_read == 0)
+                        {
+                            break;
+                        }
+                        got.append(buf, bytes_read);
+                    }
+                }
+            }
+
+            EXPECT_EQ(got, expected);
+            return 0;
+        }
+    };
+
+    int fds[2];
+    ASSERT_EQ(::pipe(fds), 0);
+
+    EXPECT_EQ(FiberScheduler::run(Params::fiberMain, Params{fds[0], fds[1]}), 0);
+
+    ::close(fds[0]);
+}
+
+} // namespace silk


### PR DESCRIPTION
Example of a potential data loss:
1. We called `FiberScheduler::read` to read from the fd.
2. Then called `future->cancel()`.
3. The cancel lands in the gap between the kernel writing the CQE to the ring and the scheduler processing the CQE.
4. The cancel does `future->result = nullptr`.
5. The scheduler does:
```
            int result = cqe->res;
            if (result >= 0)
            {
                if (future->result)
                {
                    *future->result = static_cast<uint64_t>(result);
                }
                future->set(0);
            }
```
6. Effectively, we read data from the fd, but "dropped it on the floor", and subsequent reads won't read it.

It's enough to just remove `future->result = nullptr` from `FiberScheduler::cancelIo`. And it doesn't seem like that will break any invariant.

To add a deterministic red-green test, the simplest solution I found is to inject a hook on a future which runs after reading CQE from the ring and before processing it. This code is only compiled for test builds (i.e. debug or sanitizer). Might be potentially useful for other similar tests as well.