### PR TITLE
Fiber-local storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ endif()
 
 option(BUILD_BENCHMARKS "Build benchmark targets" ON)
 
+option(SILK_FIBER_LOCAL_STORAGE "Enable fiber-local storage" OFF)
+
 include(CTest)
 include(GoogleTest)
 

--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <silk/fibers/future.h>
+#include <silk/util/platform.h>
 #include <silk/util/stack.h>
 #include <silk/util/tree.h>
 
@@ -224,6 +225,13 @@ public:
      * Valid from any context, including non-fiber threads.
      */
     static Fiber * getCurrentFiber() noexcept;
+
+#ifdef SILK_FIBER_LOCAL_STORAGE
+    /**
+     * Return the current fiber's local storage buffer (CACHELINE_SIZE bytes).
+     */
+    __attribute__((always_inline)) static void * getLocalStorage() noexcept;
+#endif
 
     /**
      * Return true if fiber is currently running.

--- a/src/fibers/CMakeLists.txt
+++ b/src/fibers/CMakeLists.txt
@@ -4,6 +4,10 @@ add_library(silk-fibers ${FIBERS_SOURCES})
 target_link_libraries(silk-fibers PUBLIC silk-util)
 target_link_libraries(silk-fibers PRIVATE Fcontext::Fcontext Liburing::Liburing)
 
+if(SILK_FIBER_LOCAL_STORAGE)
+    target_compile_definitions(silk-fibers PUBLIC SILK_FIBER_LOCAL_STORAGE)
+endif()
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <cerrno>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -198,6 +199,11 @@ public:
         uint64_t suspendTimestamp = 0;
     };
 
+#ifdef SILK_FIBER_LOCAL_STORAGE
+    // Fiber-local storage.
+    alignas(CACHELINE_SIZE) uint8_t localStorage[CACHELINE_SIZE] = {};
+#endif
+
     // Embedded node for the shared ready queue. Its memory is always valid
     // because fiberPool never frees. reservedNode points to whichever node
     // is available for the next enqueue; after each dequeue the recycled
@@ -235,10 +241,10 @@ static_assert(alignof(Fiber) >= 8);
 using WaitStack = LockFreeStack<Fiber, &Fiber::stackEntry>;
 using SuspendedList = List<Fiber, &Fiber::suspendedEntry>;
 
-// Current fiber running on this OS thread; null when idle.
+// Current fiber running on this OS thread; null until the first getCurrentFiber call.
 static thread_local Fiber * threadFiber = nullptr;
 
-// Proxy fiber for the current non-fiber thread; destroyed at thread exit.
+// Owns the proxy fiber for the current non-fiber thread; destroyed at thread exit.
 static thread_local std::unique_ptr<Fiber> proxyFiber;
 
 Fiber::Fiber(bool isProxyFiber) noexcept
@@ -314,6 +320,11 @@ bool Fiber::initialize(FiberId fiberId_, FiberMain * fiberMain_, ParametersDtor 
     fiberMain = fiberMain_;
     parametersDtor = parametersDtor_;
     fiberContext = make_fcontext(static_cast<uint8_t *>(stack) + PAGE_SIZE + fiberStackSize, fiberStackSize, fiberContextMain);
+
+#ifdef SILK_FIBER_LOCAL_STORAGE
+    // Inherit a copy of the launcher's local storage.
+    std::memcpy(localStorage, FiberScheduler::getCurrentFiber()->localStorage, sizeof(localStorage));
+#endif
 
     return true;
 }
@@ -1180,18 +1191,13 @@ FiberId FiberScheduler::getCurrentFiberId() noexcept
 
 Fiber * FiberScheduler::getCurrentFiber() noexcept
 {
-    // Fast path: thread is running a regular fiber, or has already lazily
-    // allocated a proxy fiber. Both branches stay inline; only the very first
-    // call from a non-fiber thread reaches initCurrentFiber.
-    if (threadFiber)
-    {
-        return threadFiber;
-    }
-    if (!proxyFiber) [[unlikely]]
+    // Fast path: a single TLS load.
+    // Only the first call from a thread reaches initCurrentFiber to lazily create its proxy.
+    if (!threadFiber) [[unlikely]]
     {
         initCurrentFiber();
     }
-    return proxyFiber.get();
+    return threadFiber;
 }
 
 __attribute__((noinline)) void FiberScheduler::initCurrentFiber() noexcept
@@ -1199,7 +1205,15 @@ __attribute__((noinline)) void FiberScheduler::initCurrentFiber() noexcept
     // Lazily create a proxy fiber so a non-fiber thread can still participate
     // in fiber-aware APIs (e.g. FiberMutex::lock, FiberScheduler::run-and-wait).
     proxyFiber = std::make_unique<Fiber>(true);
+    threadFiber = proxyFiber.get();
 }
+
+#ifdef SILK_FIBER_LOCAL_STORAGE
+void * FiberScheduler::getLocalStorage() noexcept
+{
+    return getCurrentFiber()->localStorage;
+}
+#endif
 
 bool FiberScheduler::isFiberRunning(Fiber * fiber) noexcept
 {
@@ -1998,9 +2012,10 @@ void FiberScheduler::runFiber(Fiber * fiber, CpuTimer * timer) noexcept
         timer->reset(simpleCounters[SCHEDULER_USER_TIME], fiber->processorNumber);
     }
 
+    Fiber * previousFiber = threadFiber;
     threadFiber = fiber;
     fiber->switchToFiberContext();
-    threadFiber = nullptr;
+    threadFiber = previousFiber;
 
     if (timer)
     {

--- a/src/fibers/tests/fiber-local-test.cpp
+++ b/src/fibers/tests/fiber-local-test.cpp
@@ -1,0 +1,75 @@
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#ifdef SILK_FIBER_LOCAL_STORAGE
+
+namespace silk
+{
+
+namespace
+{
+int getValue() noexcept
+{
+    return *static_cast<int *>(FiberScheduler::getLocalStorage());
+}
+void saveValue(int value) noexcept
+{
+    *static_cast<int *>(FiberScheduler::getLocalStorage()) = value;
+}
+}
+
+// A fiber inherits its launching thread's values on entry
+// and keeps its own values across suspend/resume.
+TEST(FiberLocalStorage, inheritsSurvivesYieldAndIsolated)
+{
+    struct Params
+    {
+        int expectedInitialValue;
+        int fiberId;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            EXPECT_EQ(getValue(), p->expectedInitialValue);
+            saveValue(p->fiberId);
+            FiberScheduler::yield();
+            EXPECT_EQ(getValue(), p->fiberId);
+            return 0;
+        }
+    };
+
+    auto launcher = [](int threadIndex)
+    {
+        int launcherValue = threadIndex;
+
+        // Non-fibers should be able to use the buffer.
+        saveValue(launcherValue);
+
+        static constexpr int FIBERS_PER_THREAD = 16;
+        FiberFuture futures[FIBERS_PER_THREAD];
+        for (int i = 0; i < FIBERS_PER_THREAD; ++i)
+        {
+            int fiberId = threadIndex * FIBERS_PER_THREAD + i;
+            int r = FiberScheduler::run(Params::fiberMain, Params{launcherValue, fiberId}, &futures[i]);
+            EXPECT_EQ(r, 0);
+        }
+        for (auto & future : futures)
+        {
+            future.wait();
+        }
+
+        EXPECT_EQ(getValue(), launcherValue);
+    };
+
+    std::thread t0(launcher, 1);
+    std::thread t1(launcher, 2);
+    t0.join();
+    t1.join();
+}
+
+} // namespace silk
+
+#endif // SILK_FIBER_LOCAL_STORAGE


### PR DESCRIPTION
Adds the following function:
```
void * FiberScheduler::getLocalStorage()
```

It returns a small (one cacheline) buffer on thread-local storage that fibers copy to/from on context switch, implementing a fiber-local storage abstraction.

Gated behind `SILK_FIBER_LOCAL_STORAGE` for clients that don't use it.

Example usage: https://github.com/ClickHouse/ClickHouse/pull/106345/changes#diff-ecac0157c8d879585589db3b2d73420ebe6fb7640c3561b7eb015fb3d788b209R30

