### PR TITLE
Introduce fiber switch hooks

### DIFF
--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <cerrno>
+#include <cstdint>
 #include <memory>
 #include <utility>
 
@@ -22,6 +23,7 @@ class Fiber;
  * Types exceeding this limit cause a compile-time error.
  */
 static constexpr uint64_t FIBER_PARAMETERS_SIZE = 64;
+static constexpr uint64_t FIBER_PARAMETERS_OFFSET = 224;
 
 /**
  * Hard cap on CPU index (largest known socket: 384 cores).
@@ -37,7 +39,12 @@ using FiberMain = int(void * parameters) noexcept;
  * Destructor for the fiber's parameter buffer. Called after the entry point returns.
  * Null for trivially destructible parameter types.
  */
-using ParametersDtor = void(void * parameters) noexcept;
+using FiberParametersDtor = void(void * parameters) noexcept;
+
+/**
+ * Fiber switch callback.  Called when fiber suspended/resumed.
+ */
+using FiberSwitchCallback = void(Fiber * fiber) noexcept;
 
 /**
  * Packed fiber identity: [category:8 | cpu:10 | counter:46] stored as uint64_t.
@@ -137,6 +144,15 @@ public:
         // isolation (e.g. head-of-line blocking benchmarks).
         // Production should leave this off.
         bool disableWorkStealing = false;
+
+        // Optional per-fiber context-switch hooks. fiberResume fires on the
+        // thread about to run the fiber, immediately before control enters it
+        // (first run and every resume); fiberSuspend fires on the same thread
+        // immediately after control leaves it (on suspend and on termination).
+        // Calls always balance, so they suit save/restore of per-fiber state
+        // across the OS thread the fiber borrows. Not invoked for proxy fibers.
+        FiberSwitchCallback * fiberSuspend = nullptr;
+        FiberSwitchCallback * fiberResume = nullptr;
     };
 
     /**
@@ -229,6 +245,11 @@ public:
      * Return true if fiber is currently running.
      */
     static bool isFiberRunning(Fiber * fiber) noexcept;
+
+    /**
+     * Return a pointer to fiber parameters block.
+     */
+    static void * getFiberParameters(Fiber * fiber) noexcept { return reinterpret_cast<uint8_t *>(fiber) + FIBER_PARAMETERS_OFFSET; }
 
     /**
      * Resume a suspended fiber.
@@ -574,8 +595,8 @@ private:
 
     static void buildStealCandidates() noexcept;
     static void initCurrentFiber() noexcept;
-    static void * getFiberParameters(Fiber * fiber) noexcept;
-    static Fiber * allocateFiber(FiberMain * fiberMain, ParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept;
+    static Fiber *
+    allocateFiber(FiberMain * fiberMain, FiberParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept;
     static void freeFiber(Fiber * fiber) noexcept;
     static void enqueueReady(Fiber * fiber) noexcept;
     static void yieldSuspendCallback(Fiber * fiber, void * context) noexcept;

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -112,7 +113,7 @@ public:
     Fiber(bool isProxyFiber = false) noexcept;
     ~Fiber() noexcept;
 
-    bool initialize(FiberId fiberId, FiberMain * fiberMain, ParametersDtor * parametersDtor, FiberFuture * waitingFuture) noexcept;
+    bool initialize(FiberId fiberId, FiberMain * fiberMain, FiberParametersDtor * parametersDtor, FiberFuture * waitingFuture) noexcept;
     void deinitialize() noexcept;
 
     void switchToFiberContext() noexcept;
@@ -183,7 +184,7 @@ public:
         // by run for non-trivially-destructible T and called by
         // fiberContextMain immediately after fiberMain returns.
         FiberMain * fiberMain = nullptr;
-        ParametersDtor * parametersDtor = nullptr;
+        FiberParametersDtor * parametersDtor = nullptr;
 
         // Set by run to the FiberFuture to notify on completion.
         FiberFuture * waitingFuture = nullptr;
@@ -232,6 +233,8 @@ public:
 // are always zero, so the full 64-bit address fits in either field without masking.
 static_assert(alignof(Fiber) >= 8);
 
+static_assert(offsetof(Fiber, parameters) == FIBER_PARAMETERS_OFFSET);
+
 using WaitStack = LockFreeStack<Fiber, &Fiber::stackEntry>;
 using SuspendedList = List<Fiber, &Fiber::suspendedEntry>;
 
@@ -268,7 +271,8 @@ Fiber::~Fiber() noexcept
     }
 }
 
-bool Fiber::initialize(FiberId fiberId_, FiberMain * fiberMain_, ParametersDtor * parametersDtor_, FiberFuture * waitingFuture_) noexcept
+bool Fiber::initialize(
+    FiberId fiberId_, FiberMain * fiberMain_, FiberParametersDtor * parametersDtor_, FiberFuture * waitingFuture_) noexcept
 {
     state.store(FiberState::SUSPENDED, std::memory_order_relaxed);
 
@@ -1206,13 +1210,8 @@ bool FiberScheduler::isFiberRunning(Fiber * fiber) noexcept
     return fiber->state.load(std::memory_order_acquire) == FiberState::RUNNING;
 }
 
-void * FiberScheduler::getFiberParameters(Fiber * fiber) noexcept
-{
-    return fiber->parameters;
-}
-
 Fiber *
-FiberScheduler::allocateFiber(FiberMain * fiberMain, ParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept
+FiberScheduler::allocateFiber(FiberMain * fiberMain, FiberParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept
 {
     Fiber * fiber = scheduler->fiberPool.allocate();
     if (fiber)
@@ -1999,7 +1998,25 @@ void FiberScheduler::runFiber(Fiber * fiber, CpuTimer * timer) noexcept
     }
 
     threadFiber = fiber;
+
+    // Fiber gains the CPU: fires on the first run and on every resume. Runs on
+    // the scheduler thread immediately before control transfers into the fiber;
+    // since jump_fcontext is a same-thread stack switch, anything the callback
+    // installs (e.g. thread-local execution context) is visible to fiber code.
+    if (options.fiberResume)
+    {
+        options.fiberResume(fiber);
+    }
+
     fiber->switchToFiberContext();
+
+    // Fiber relinquishes the CPU: fires whether it suspended (will resume later)
+    // or stopped (terminated), so fiberResume/fiberSuspend calls always balance.
+    if (options.fiberSuspend)
+    {
+        options.fiberSuspend(fiber);
+    }
+
     threadFiber = nullptr;
 
     if (timer)


### PR DESCRIPTION
# Summary

Adds optional per-fiber context-switch callbacks (fiberResume / fiberSuspend) to FiberScheduler::Options, letting callers run code on the scheduler thread immediately before a fiber gains the CPU and immediately after it relinquishes it. This is the hook point for saving/restoring per-fiber state (e.g. a thread-local execution context) across the OS thread a fiber borrows.

# Motivation

Fibers cooperatively borrow scheduler OS threads and may be resumed on a different thread than the one they suspended on. Any state pinned to the OS thread (thread-locals, logging context, accounting) needs to be swapped in/out as fibers switch. These hooks provide a clean, balanced place to do that without baking specific concerns into the scheduler core.

# What changed

- New callback type FiberSwitchCallback = void(Fiber *) noexcept and two new Options fields:
  - fiberResume — fires on the thread about to run the fiber, immediately before control enters it (first run and every resume).
  - fiberSuspend — fires on the same thread immediately after control leaves it (on suspend and on termination).
  - Calls always balance (every resume is paired with a suspend), so they're safe for save/restore. Not invoked for proxy fibers.
- Hooks wired into runFiber around switchToFiberContext(). Because jump_fcontext is a same-thread stack switch, anything fiberResume installs is visible to fiber code.
- getFiberParameters made public + inlined as a static offset computation (fiber + FIBER_PARAMETERS_OFFSET) so callers can reach a fiber's parameter block. Backed by a new static_assert(offsetof(Fiber, parameters) == FIBER_PARAMETERS_OFFSET) to keep the constant in sync with the layout.
- Rename ParametersDtor → FiberParametersDtor for naming consistency across the fiber API.

# Example

```
FiberScheduler::Options opts;
opts.fiberSuspend = [](Fiber * fiber) noexcept
{
    CHFiberParams * params = static_cast<CHFiberParams *>(FiberScheduler::getFiberParameters(fiber));
    params->threadStatus = current_thread;
};
opts.fiberResume = [](Fiber * fiber) noexcept
{
    CHFiberParams * params = static_cast<CHFiberParams *>(FiberScheduler::getFiberParameters(fiber));
    current_thread = params->threadStatus;
};
FiberScheduler::initialize(opts);
```
