### PR TITLE
chore(file-perf): fix the confusing error log

### DIFF
--- a/src/perf/file-perf.cpp
+++ b/src/perf/file-perf.cpp
@@ -298,7 +298,10 @@ int Benchmark::workerFiberMain(WorkerFiberParams * params) noexcept
     for (uint32_t i = 0; i < benchmark->cfg.iodepth; ++i)
     {
         int r = job->slots[i].future.wait();
-        SILK_ERROR("request failed: %s", std::strerror(r));
+        if (r)
+        {
+            SILK_ERROR("request failed: %s", std::strerror(r));
+        }
     }
 
     return 0;


### PR DESCRIPTION
Noticed when running `--flamegraph` on file-perf.

It prints confusing error message (`src/perf/file-perf.cpp:301: request failed: Success`) even on success cases.

```
$ ./bb -b release file-perf --flamegraph
2026-06-07 22:23:40.561 [INFO ] bb:1970: command=file-perf preset=release
[0/2] Re-checking globbed directories...
ninja: no work to do.

## file-perf -- async file I/O

file=/dev/shm/file-perf.bin, bs=4k, size=1g, duration=10s, warmup=2s

[0/2] Re-checking globbed directories...
ninja: no work to do.
2026-06-07 22:23:40.621 [INFO ] bb:443: profiling file-perf -> /home/kavi/src/silk/build/release/file-perf.flamegraph.svg
2026-06-07 20:23:40.700 [INFO ] src/perf/file-perf.cpp:432: starting benchmark on: /dev/shm/file-perf.bin  size=1.0GiB
2026-06-07 20:23:40.701 [INFO ] src/perf/file-perf.cpp:436: starting benchmark
2026-06-07 20:23:40.701 [INFO ] src/perf/file-perf.cpp:443: warming up for 2s...
2026-06-07 20:23:40.987 [INFO ] src/profiler/main.cpp:178: profiling pid 2815514 at 99 Hz -- Ctrl+C to stop
2026-06-07 20:23:42.701 [INFO ] src/perf/file-perf.cpp:449: measuring for 10s...
2026-06-07 20:23:52.701 [INFO ] src/perf/file-perf.cpp:455: stopping benchmark
2026-06-07 20:23:52.701 [ERROR] src/perf/file-perf.cpp:301: request failed: Success
2026-06-07 20:23:52.701 [ERROR] src/perf/file-perf.cpp:301: request failed: Success
2026-06-07 20:23:52.701 [ERROR] src/perf/file-perf.cpp:301: request failed: Success
2026-06-07 20:23:52.701 [ERROR] src/perf/file-perf.cpp:301: request failed: Success
2026-06-07 20:23:52.701 [ERROR] src/perf/file-perf.cpp:301: request failed: Success
2026-06-07 20:23:52.701 [ERROR] src/perf/file-perf.cpp:301: request failed: Success

````
After the patch, it doesn't print this confusing error in case of success cases.

```
$ ./bb -b release file-perf --flamegraph
2026-06-07 22:33:33.057 [INFO ] bb:1970: command=file-perf preset=release
[0/2] Re-checking globbed directories...
ninja: no work to do.

## file-perf -- async file I/O

file=/dev/shm/file-perf.bin, bs=4k, size=1g, duration=10s, warmup=2s

[0/2] Re-checking globbed directories...
ninja: no work to do.
2026-06-07 22:33:33.125 [INFO ] bb:443: profiling file-perf -> /home/kavi/src/silk/build/release/file-perf.flamegraph.svg
2026-06-07 20:33:33.212 [INFO ] src/perf/file-perf.cpp:435: starting benchmark on: /dev/shm/file-perf.bin  size=1.0GiB
2026-06-07 20:33:33.212 [INFO ] src/perf/file-perf.cpp:439: starting benchmark
2026-06-07 20:33:33.213 [INFO ] src/perf/file-perf.cpp:446: warming up for 2s...
2026-06-07 20:33:33.505 [INFO ] src/profiler/main.cpp:178: profiling pid 2817925 at 99 Hz -- Ctrl+C to stop
2026-06-07 20:33:35.213 [INFO ] src/perf/file-perf.cpp:452: measuring for 10s...
2026-06-07 20:33:45.213 [INFO ] src/perf/file-perf.cpp:458: stopping benchmark
2026-06-07 20:33:45.487 [INFO ] src/profiler/main.cpp:186: collecting results...
2026-06-07 22:33:45.531 [INFO ] bb:474: folded stacks: /home/kavi/src/silk/build/release/file-perf.flamegraph.folded
2026-06-07 22:33:45.531 [INFO ] bb:475: flamegraph: /home/kavi/src/silk/build/release/file-perf.flamegraph.svg

```