### PR TITLE
Read thread-locals safely when fibers migrate OS threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Fibers are lightweight stackful coroutines that suspend rather than block their 
 
 ## Documentation
 
+- [`docs/coroutines.md`](docs/coroutines.md) — stackless coroutines vs stackful fibers: design differences and performance data
+- [`docs/perf.md`](docs/perf.md) — `net-perf` and `file-perf` benchmark results and fio comparison
 - [`docs/scheduler.md`](docs/scheduler.md) — scheduler loop, context switching, suspension pattern, async IO, sleep cancellation, work-stealing design, and performance benchmarks
 - [`docs/sync.md`](docs/sync.md) — synchronization primitives: `FiberFuture`, `FiberFutex`, `FiberMutex`, `FiberSequencer`, `FiberEvent`, `FairFiberMutex`
+- [`docs/tls.md`](docs/tls.md) - thread-local storage with migrating fibers: why native `thread_local` is unsafe across a suspension, the rules for fiber code, and how silk hardens its own context accessors
 - [`docs/util.md`](docs/util.md) — utility library: lock-free data structures, TSC timing, memory pool, CPU topology, logging, assertions
-- [`docs/perf.md`](docs/perf.md) — `net-perf` and `file-perf` benchmark results and fio comparison
-- [`docs/coroutines.md`](docs/coroutines.md) — stackless coroutines vs stackful fibers: design differences and performance data
 - [`src/fibers/tests/`](src/fibers/tests/) — usage examples: fiber lifecycle, futures, synchronization primitives, async IO
 - [`src/gdb/fiber.py`](src/gdb/fiber.py) — GDB extension; load with `source src/gdb/fiber.py`, then use `fiber-list`, `fiber-savecontext`, `fiber-restorecontext`, `fiber-switchcontext`
 

--- a/docs/coroutines.md
+++ b/docs/coroutines.md
@@ -98,8 +98,7 @@ Condition 2 is violated by any real scheduler (work-stealing or otherwise). HALO
 
 ### Context switch cost
 
-From "Stackless vs. Stackful Coroutines: A Comparative Study" (SC '25 Workshops, 2025):
-https://dl.acm.org/doi/10.1145/3731599.3767502
+From "Stackless vs. Stackful Coroutines: A Comparative Study" (SC '25 Workshops, 2025): https://dl.acm.org/doi/10.1145/3731599.3767502
 
 | | Context switch | Task creation |
 |---|---|---|
@@ -140,8 +139,7 @@ A stackless coroutine task creation (heap frame allocation + `get_return_object`
 
 ### Deep call chains
 
-From "Stackful Coroutine Made Fast" (Alibaba Photon, October 2024):
-https://photonlibos.github.io/blog-20241014/stackful-coroutine-made-fast.html
+From "Stackful Coroutine Made Fast" (Alibaba Photon, October 2024): https://photonlibos.github.io/blog-20241014/stackful-coroutine-made-fast.html
 
 Tower of Hanoi benchmark (recursive workload, increasing call depth):
 
@@ -169,8 +167,7 @@ With `mmap`-based stack allocation (4 KB alignment, ASLR), different fibers get 
 
 ### Heap allocation overhead per request
 
-From "CoroBase: Coroutine-Oriented Main-Memory Database Engine" (VLDB 2021):
-http://vldb.org/pvldb/vol14/p431-he.pdf
+From "CoroBase: Coroutine-Oriented Main-Memory Database Engine" (VLDB 2021): http://vldb.org/pvldb/vol14/p431-he.pdf
 
 Measured **808 bytes per request** in nested coroutine frames (5+ frames in a chain), demonstrating how heap allocation cost accumulates with call depth.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -2,13 +2,9 @@
 
 ## Overview
 
-This is a cooperative fiber scheduler with per-CPU threads and io_uring
-integration. Each CPU runs one scheduler thread that owns its own io_uring ring,
-ready queue, sleep tree, and wakeup signaling infrastructure.
+This is a cooperative fiber scheduler with per-CPU threads and io_uring integration. Each CPU runs one scheduler thread that owns its own io_uring ring, ready queue, sleep tree, and wakeup signaling infrastructure.
 
-Source lives under `src/fibers/`. Data structures and utilities are in
-`src/util/` (see `docs/util.md`). Synchronization primitives are in
-`docs/sync.md`.
+Source lives under `src/fibers/`. Data structures and utilities are in `src/util/` (see `docs/util.md`). Synchronization primitives are in `docs/sync.md`.
 
 ---
 
@@ -22,12 +18,9 @@ Source lives under `src/fibers/`. Data structures and utilities are in
 - A sleep tree (`SleepTree`) ordered by TSC deadline
 - A sleep inbox and cancel inbox (`LockFreeStack`) for lock-free handoff
 
-Each iteration always runs both `handleReadyQueue` and `runServiceLoop`,
-regardless of whether the first found work. Any work resets the idle counters
-and immediately continues the loop.
+Each iteration always runs both `handleReadyQueue` and `runServiceLoop`, regardless of whether the first found work. Any work resets the idle counters and immediately continues the loop.
 
-If the own CPU has nothing to do, `runStealLoop` is attempted next. If all
-three produce nothing, the thread enters the spin/sleep phase.
+If the own CPU has nothing to do, `runStealLoop` is attempted next. If all three produce nothing, the thread enters the spin/sleep phase.
 
 When idle, `parkThread` calls `io_uring_enter2` with a `waitNs` timeout; cross-CPU wakeup is delivered by writing to an eventfd that is polled persistently in the ring (`IORING_POLL_ADD_MULTI`), producing a CQE that wakes `io_uring_enter2`.
 
@@ -35,48 +28,27 @@ When idle, `parkThread` calls `io_uring_enter2` with a `waitNs` timeout; cross-C
 
 ## Context Switching
 
-Context switching uses Boost.Context (`fcontext_t`). Each fiber has a 64 KB
-mmap'd stack with a guard page at each end (bottom and top). ASan stack-swap
-annotations are included.
+Context switching uses Boost.Context (`fcontext_t`). Each fiber has a 64 KB mmap'd stack with a guard page at each end (bottom and top). ASan stack-swap annotations are included.
 
-Fiber lifecycle: `SUSPENDED -> READY -> RUNNING -> STOPPED`.
-`SUSPEND_REQUESTED` is a transient state entered at the start of `suspend`;
-the suspend callback runs while the fiber is in this state, then the fiber
-transitions to either `SUSPENDED` (genuine suspension) or `READY` (if
-`schedule` was called during the callback, cancelling the suspension).
+Fiber lifecycle: `SUSPENDED -> READY -> RUNNING -> STOPPED`. `SUSPEND_REQUESTED` is a transient state entered at the start of `suspend`; the suspend callback runs while the fiber is in this state, then the fiber transitions to either `SUSPENDED` (genuine suspension) or `READY` (if `schedule` was called during the callback, cancelling the suspension).
 
-`FiberState` is defined in `fiber.cpp` (not `fiber.h`) as an implementation detail.
-`SleepFuture`, `SleepStack`, and `SleepTree` are declared/aliased in the private
-section of `FiberScheduler` (in `fiber.h`) so they are accessible from `fiber.cpp`.
+`FiberState` is defined in `fiber.cpp` (not `fiber.h`) as an implementation detail. `SleepFuture`, `SleepStack`, and `SleepTree` are declared/aliased in the private section of `FiberScheduler` (in `fiber.h`) so they are accessible from `fiber.cpp`.
 
-`processorNumber` tracks which CPU's ready queue the fiber targets. It is set by
-`schedule()` on first dispatch (assigned to the current CPU when still
-`UINT32_MAX`) and updated by `runStealLoop` when a fiber is stolen (reassigned
-to the stealing CPU). When a fiber runs on a worker thread via thread mode,
-`processorNumber` is not updated - the fiber returns to its last assigned CPU's
-queue on `exitThreadMode()`.
+`processorNumber` tracks which CPU's ready queue the fiber targets. It is set by `schedule()` on first dispatch (assigned to the current CPU when still `UINT32_MAX`) and updated by `runStealLoop` when a fiber is stolen (reassigned to the stealing CPU). When a fiber runs on a worker thread via thread mode, `processorNumber` is not updated - the fiber returns to its last assigned CPU's queue on `exitThreadMode()`.
 
 ---
 
 ## Suspension Pattern
 
-`FiberScheduler::suspend(callback, ctx)` suspends the current fiber and invokes
-`callback` while the fiber is parked. The callback is responsible for arranging
-the wakeup (e.g. enqueuing as a waiter). The callback must handle the race where
-the event already arrived before parking.
+`FiberScheduler::suspend(callback, ctx)` suspends the current fiber and invokes `callback` while the fiber is parked. The callback is responsible for arranging the wakeup (e.g. enqueuing as a waiter). The callback must handle the race where the event already arrived before parking.
 
-The callback and its context are stored on the `Fiber` itself
-(`suspendCallback`/`suspendContext`) and cleared by `runFiber` after invocation.
-This allows `runFiber` to be called from both scheduler threads and thread pool
-workers without per-CPU state.
+The callback and its context are stored on the `Fiber` itself (`suspendCallback`/`suspendContext`) and cleared by `runFiber` after invocation. This allows `runFiber` to be called from both scheduler threads and thread pool workers without per-CPU state.
 
 ---
 
 ## Thread Mode
 
-A fiber that needs to make blocking syscalls or perform heavy CPU work can
-escape the cooperative scheduler without stalling its scheduler thread by
-entering thread mode.
+A fiber that needs to make blocking syscalls or perform heavy CPU work can escape the cooperative scheduler without stalling its scheduler thread by entering thread mode.
 
 ```cpp
 {
@@ -87,21 +59,12 @@ entering thread mode.
 
 There are two ready queues:
 
-- **Per-CPU ready queue** (`ProcessorState::readyQueue`) - bounded MPMC queue
-  drained by the CPU's scheduler thread. Normal cooperative fibers live here.
-- **Shared ready queue** (`SchedulerState::readyQueue`) - unbounded MPMC queue
-  drained by the worker thread pool. Thread-mode fibers live here, and normal
-  fibers overflow here when a CPU ready queue is full.
+- **Per-CPU ready queue** (`ProcessorState::readyQueue`) - bounded MPMC queue drained by the CPU's scheduler thread. Normal cooperative fibers live here.
+- **Shared ready queue** (`SchedulerState::readyQueue`) - unbounded MPMC queue drained by the worker thread pool. Thread-mode fibers live here, and normal fibers overflow here when a CPU ready queue is full.
 
-`enterThreadMode()` sets `fiber->inThreadMode` and calls `schedule()`, which
-routes the fiber to the shared ready queue. A worker thread dequeues it and runs
-it via `runFiber(nullptr, fiber)`, where it may block freely. When the fiber
-suspends inside thread mode (e.g. waiting on a future), `schedule()` re-enqueues
-it to the shared ready queue when it is woken - any free worker picks it up.
+`enterThreadMode()` sets `fiber->inThreadMode` and calls `schedule()`, which routes the fiber to the shared ready queue. A worker thread dequeues it and runs it via `runFiber(nullptr, fiber)`, where it may block freely. When the fiber suspends inside thread mode (e.g. waiting on a future), `schedule()` re-enqueues it to the shared ready queue when it is woken - any free worker picks it up.
 
-`exitThreadMode()` clears `fiber->inThreadMode` and calls `schedule()`, which
-routes the fiber back to its CPU's per-CPU ready queue. After this point the
-fiber runs cooperatively again.
+`exitThreadMode()` clears `fiber->inThreadMode` and calls `schedule()`, which routes the fiber back to its CPU's per-CPU ready queue. After this point the fiber runs cooperatively again.
 
 `schedule()` routing summary:
 - `inThreadMode = true` => shared ready queue
@@ -112,20 +75,15 @@ fiber runs cooperatively again.
 
 ## Synchronization Primitives
 
-`FiberMutex`, `FiberFutex`, `FiberSequencer`, `FiberEvent`, and
-`FairFiberMutex` are documented in `docs/sync.md`.
+`FiberMutex`, `FiberFutex`, `FiberSequencer`, `FiberEvent`, and `FairFiberMutex` are documented in `docs/sync.md`.
 
-`FiberMutex` and `FiberFutex` use the scheduler's waiter table directly
-(`enqueueWaiter` / `releaseWaiters`, keyed by `this`). The higher-level
-primitives build on `FiberSequencer`, which manages its own ordered waiter tree
-via a combiner lock.
+`FiberMutex` and `FiberFutex` use the scheduler's waiter table directly (`enqueueWaiter` / `releaseWaiters`, keyed by `this`). The higher-level primitives build on `FiberSequencer`, which manages its own ordered waiter tree via a combiner lock.
 
 ---
 
 ## Data Structures
 
-The scheduler uses `LockFreeStack`, `BoundedQueue`, `Queue`, `Tree`, and
-`MemoryPool` from `src/util/`. See `docs/util.md` for full descriptions.
+The scheduler uses `LockFreeStack`, `BoundedQueue`, `Queue`, `Tree`, and `MemoryPool` from `src/util/`. See `docs/util.md` for full descriptions.
 
 Key usages:
 - `MemoryPool` - fiber allocation (rseq fast path, zero atomics)
@@ -137,78 +95,48 @@ Key usages:
 
 ## Timing
 
-All sleep deadlines are in TSC cycles. `Tsc::getCycles()` is `rdtsc` /
-`cntvct_el0`. Conversion uses fixed-point multiply-shift
-(`cycles * nsPerCycleFp >> 20`) - no division on the hot path. Frequency is
-detected once at startup via CPUID / hypervisor leaves / `cntfrq_el0`. See
-`docs/util.md` for details.
+All sleep deadlines are in TSC cycles. `Tsc::getCycles()` is `rdtsc` / `cntvct_el0`. Conversion uses fixed-point multiply-shift (`cycles * nsPerCycleFp >> 20`) - no division on the hot path. Frequency is detected once at startup via CPUID / hypervisor leaves / `cntfrq_el0`. See `docs/util.md` for details.
 
 ---
 
 ## Async IO
 
-Each of `read`, `write`, and `poll` has two overloads: a blocking form that
-submits an io_uring SQE and suspends the fiber until completion, and an async
-form that submits the SQE and returns immediately with an `IoFuture*` the caller
-waits on separately. `handleCompletionQueue` processes CQEs, extracts the
-`IoFuture*` from the CQE user data, and calls `future->set()` to wake the
-waiting fiber.
+Each of `read`, `write`, and `poll` has two overloads: a blocking form that submits an io_uring SQE and suspends the fiber until completion, and an async form that submits the SQE and returns immediately with an `IoFuture*` the caller waits on separately. `handleCompletionQueue` processes CQEs, extracts the `IoFuture*` from the CQE user data, and calls `future->set()` to wake the waiting fiber.
 
 ---
 
 ## Sleep Cancellation
 
-`SleepFuture` has an atomic `state` with two bits: `IN_TABLE` (entry is in the
-sleep tree) and `CANCELLED`. `cancelSleep` does a `fetch_or(CANCELLED)` -- if
-`IN_TABLE` was set, it also pushes the entry onto `cancelQueue`.
-`handleCancelQueue` drains `cancelQueue` and calls `sleepTree.remove()` directly
-(O(log n), no scan).
+`SleepFuture` has an atomic `state` with two bits: `IN_TABLE` (entry is in the sleep tree) and `CANCELLED`. `cancelSleep` does a `fetch_or(CANCELLED)` -- if `IN_TABLE` was set, it also pushes the entry onto `cancelQueue`. `handleCancelQueue` drains `cancelQueue` and calls `sleepTree.remove()` directly (O(log n), no scan).
 
-The `StackEntry` inside `SleepFuture` is shared between `sleepQueue` and
-`cancelQueue` - only one can hold it at a time, enforced by the `IN_TABLE` flag.
+The `StackEntry` inside `SleepFuture` is shared between `sleepQueue` and `cancelQueue` - only one can hold it at a time, enforced by the `IN_TABLE` flag.
 
 ---
 
 ## Work-Stealing
 
-An idle CPU can steal fibers from a neighbor's ready queue and claim a
-neighbor's frozen service loop to process its pending completions and
-expirations. Without stealing, load imbalance is permanent and service loop
-starvation occurs while a scheduler thread is inside a fiber.
+An idle CPU can steal fibers from a neighbor's ready queue and claim a neighbor's frozen service loop to process its pending completions and expirations. Without stealing, load imbalance is permanent and service loop starvation occurs while a scheduler thread is inside a fiber.
 
 ### Service Loop Claiming
 
-`runServiceLoop` processes io_uring CQEs (`handleCompletionQueue`), the sleep
-inbox (`handleSleepQueue`), cancellation requests (`handleCancelQueue`), and
-expired waiters (`handleExpiredWaiters`), then calls `enqueueWakeup` to arm the
-next sleep deadline. It is protected by `serviceLoopLock` so at most one thread
-runs the service loop for a given processor at a time.
+`runServiceLoop` processes io_uring CQEs (`handleCompletionQueue`), the sleep inbox (`handleSleepQueue`), cancellation requests (`handleCancelQueue`), and expired waiters (`handleExpiredWaiters`), then calls `enqueueWakeup` to arm the next sleep deadline. It is protected by `serviceLoopLock` so at most one thread runs the service loop for a given processor at a time.
 
-- **Owner thread**: try-locks before running its own service loop. If a helper
-  holds the lock, the owner skips it entirely - the helper is already doing the
-  work.
-- **Helper thread**: try-locks the victim's lock; if it fails, moves to the next
-  candidate.
+- **Owner thread**: try-locks before running its own service loop. If a helper holds the lock, the owner skips it entirely - the helper is already doing the work.
+- **Helper thread**: try-locks the victim's lock; if it fails, moves to the next candidate.
 
 `enqueueWakeup` runs inside the locked section to eliminate a race where a helper could concurrently modify `sleepTree` while the owner armed the next deadline.
 
-`enqueueWakeup` is excluded from the `didWork` return value - it is preparation
-for sleeping, not productive work. Counting it would cause a spin loop.
+`enqueueWakeup` is excluded from the `didWork` return value - it is preparation for sleeping, not productive work. Counting it would cause a spin loop.
 
-Fibers woken by a claimed service loop are enqueued via `schedule()` using
-`fiber->processorNumber`, routing them back to the victim's ready queue.
+Fibers woken by a claimed service loop are enqueued via `schedule()` using `fiber->processorNumber`, routing them back to the victim's ready queue.
 
 ### Fiber Stealing
 
-An idle CPU dequeues fibers from a neighbor's `readyQueue` and runs them
-locally. `BoundedQueue` is MPMC, so `victim->readyQueue.dequeue()` is safe from
-any thread.
+An idle CPU dequeues fibers from a neighbor's `readyQueue` and runs them locally. `BoundedQueue` is MPMC, so `victim->readyQueue.dequeue()` is safe from any thread.
 
 ### Victim Selection
 
-`buildStealCandidates()` runs once at `initialize()`. For each active CPU it
-builds a `stealCandidates[]` array sorted by estimated steal cost (cheapest
-first). Topology is read from sysfs:
+`buildStealCandidates()` runs once at `initialize()`. For each active CPU it builds a `stealCandidates[]` array sorted by estimated steal cost (cheapest first). Topology is read from sysfs:
 
 - `/sys/devices/system/cpu/cpuN/topology/core_id`
 - `/sys/devices/system/cpu/cpuN/topology/physical_package_id`
@@ -222,32 +150,21 @@ Cost tiers:
 | Same socket | ~50 us |
 | Cross-socket | ~500 us |
 
-Thresholds reflect cache warming cost: fiber stealing moves potentially hundreds
-of KB of stack and heap data, while service loop claiming touches a bounded ~2 KB
-io_uring CQ. Within each tier, candidates are shuffled randomly (seeded by CPU
-number) to spread load. Inactive CPUs get `UINT64_MAX` cost and sort to the end.
-If sysfs is unavailable, all active CPUs get the same fallback cost.
+Thresholds reflect cache warming cost: fiber stealing moves potentially hundreds of KB of stack and heap data, while service loop claiming touches a bounded ~2 KB io_uring CQ. Within each tier, candidates are shuffled randomly (seeded by CPU number) to spread load. Inactive CPUs get `UINT64_MAX` cost and sort to the end. If sysfs is unavailable, all active CPUs get the same fallback cost.
 
 ### Steal Loop
 
-`runStealLoop` computes `idleCycles = now - idleSinceCycles` and a budget
-deadline of `now + idleCycles`. It walks `stealCandidates[]` cheapest first,
-breaking immediately if `idleCycles < candidate->costCycles`. For each
-candidate it:
+`runStealLoop` computes `idleCycles = now - idleSinceCycles` and a budget deadline of `now + idleCycles`. It walks `stealCandidates[]` cheapest first, breaking immediately if `idleCycles < candidate->costCycles`. For each candidate it:
 
 1. Calls `runServiceLoop(victim)` - the `try_lock` handles concurrency.
-2. Drains `victim->readyQueue` via repeated `dequeue()`, calling `runFiber` for
-   each fiber, until the queue is empty or the budget deadline passes.
+2. Drains `victim->readyQueue` via repeated `dequeue()`, calling `runFiber` for each fiber, until the queue is empty or the budget deadline passes.
 
-The deadline is shared across all candidates and all fiber steals, bounding
-total steal time to `idleCycles`.
+The deadline is shared across all candidates and all fiber steals, bounding total steal time to `idleCycles`.
 
 ### Idle Progression
 
-- `waitNs` starts at `INITIAL_WAIT_NS` (1 us) and doubles each idle iteration
-  up to `MAX_WAIT_NS` (10 ms).
-- While `waitNs < SPIN_THRESHOLD_NS` (20 us): `spinWait()` runs 64 x
-  `cpuPause()` iterations (~2 us) checking `hasWork()`.
+- `waitNs` starts at `INITIAL_WAIT_NS` (1 us) and doubles each idle iteration up to `MAX_WAIT_NS` (10 ms).
+- While `waitNs < SPIN_THRESHOLD_NS` (20 us): `spinWait()` runs 64 x `cpuPause()` iterations (~2 us) checking `hasWork()`.
 - Once `waitNs >= SPIN_THRESHOLD_NS`: `parkThread` calls `io_uring_enter2` with a `waitNs` timeout. The timed wait ensures sleeping CPUs wake periodically to attempt stealing even without an explicit wakeup.
 
 Any productive iteration resets `waitNs` back to `INITIAL_WAIT_NS`.
@@ -265,15 +182,11 @@ Measurements on a 32-CPU x86 machine (Intel Xeon Platinum 8488C, 3.6 GHz, shared
 | Raw `fcontext` (no scheduler) | ~6.5 ns | ~3.3 ns |
 | Scheduler yield (`yield()` -> re-schedule -> resume) | ~81 ns | ~40 ns |
 
-The raw `fcontext` round-trip is two `jump_fcontext` calls with no other work.
-The scheduler yield round-trip goes fiber -> scheduler loop -> ready queue
-enqueue -> dequeue -> fiber, adding ready queue and state transition overhead.
+The raw `fcontext` round-trip is two `jump_fcontext` calls with no other work. The scheduler yield round-trip goes fiber -> scheduler loop -> ready queue enqueue -> dequeue -> fiber, adding ready queue and state transition overhead.
 
 ### Thread producer (semaphore join)
 
-The main thread schedules fibers via `run()`; completion is delivered through a
-POSIX semaphore. All fibers land on the main thread's CPU and are stolen by the
-remaining 31 scheduler threads.
+The main thread schedules fibers via `run()`; completion is delivered through a POSIX semaphore. All fibers land on the main thread's CPU and are stolen by the remaining 31 scheduler threads.
 
 | N | Wall / iter | Throughput |
 |---|---|---|
@@ -283,19 +196,13 @@ remaining 31 scheduler threads.
 | 64 | ~390 ns | ~2.6M fibers/s |
 | 256 | ~390 ns | ~2.6M fibers/s |
 
-Throughput saturates at N=16. At saturation, wall time ~= CPU time (~360 ns):
-the main thread is never blocking. The bottleneck is its own join+schedule loop.
+Throughput saturates at N=16. At saturation, wall time ~= CPU time (~360 ns): the main thread is never blocking. The bottleneck is its own join+schedule loop.
 
-**Bottleneck breakdown (~360 ns at saturation):** pool and queue ops account for
-~55 ns. The remaining ~305 ns is cache-line transfer overhead - each
-join+schedule cycle forces the main thread to reclaim ownership of lines last
-written by the stealing CPU (~65 ns per transfer, 4-6 transfers).
+**Bottleneck breakdown (~360 ns at saturation):** pool and queue ops account for ~55 ns. The remaining ~305 ns is cache-line transfer overhead - each join+schedule cycle forces the main thread to reclaim ownership of lines last written by the stealing CPU (~65 ns per transfer, 4-6 transfers).
 
 ### Fiber producer (FiberFuture)
 
-The benchmark loop runs inside a driver fiber; child completion is delivered via
-`FiberFuture`. Fibers spin for a configurable number of `cpuPause()` iterations
-to simulate work (~35 ns per pause).
+The benchmark loop runs inside a driver fiber; child completion is delivered via `FiberFuture`. Fibers spin for a configurable number of `cpuPause()` iterations to simulate work (~35 ns per pause).
 
 | N | Spin | Work | Wall / iter | Speedup vs N=1 |
 |---|---|---|---|---|
@@ -308,31 +215,19 @@ to simulate work (~35 ns per pause).
 | 1 | 10000 | ~350 us | ~121000 ns | -- |
 | 16 | 10000 | ~350 us | ~10900 ns | ~11x |
 
-For no-op fibers, N=16 yields 1.7x — steal and scheduling overhead limits gains
-at small work. As fiber work grows, parallelism dominates: at ~350 us of work
-per fiber, 16 in-flight fibers run 11x faster than serial, close to linear
-scaling.
+For no-op fibers, N=16 yields 1.7x — steal and scheduling overhead limits gains at small work. As fiber work grows, parallelism dominates: at ~350 us of work per fiber, 16 in-flight fibers run 11x faster than serial, close to linear scaling.
 
-**Fiber producer advantage:** replacing `join` with `FiberFuture` eliminates the
-POSIX semaphore from the hot path. For no-op fibers at N=1, this gives ~30x
-lower latency (~350 ns vs ~11 us).
+**Fiber producer advantage:** replacing `join` with `FiberFuture` eliminates the POSIX semaphore from the hot path. For no-op fibers at N=1, this gives ~30x lower latency (~350 ns vs ~11 us).
 
 ### io_uring fiber ping-pong
 
-Two fibers exchange bytes through a pipe, both using io_uring for IO. Each
-iteration is one full round-trip: ping writes, pong reads (suspends on CQE),
-pong writes back, ping reads (suspends on CQE). Writes complete inline. Isolates
-the cost of one async io_uring cycle through the scheduler: SQE submit -> fiber
-suspend -> CQE -> fiber resume.
+Two fibers exchange bytes through a pipe, both using io_uring for IO. Each iteration is one full round-trip: ping writes, pong reads (suspends on CQE), pong writes back, ping reads (suspends on CQE). Writes complete inline. Isolates the cost of one async io_uring cycle through the scheduler: SQE submit -> fiber suspend -> CQE -> fiber resume.
 
 | Benchmark | Round-trip | Per io_uring op |
 |---|---|---|
 | `IoUringFiberPingPong` | ~7.6 µs | ~3.8 µs |
 
-The ~3.8 µs per operation matches file-perf's 3-5 µs p50 at `numjobs=1
-iodepth=1`. The TCP echo p50 of ~23 µs follows directly: 4 io_uring operations
-(server read, server write, client read, client write) x ~3.8 µs plus kernel
-TCP processing overhead.
+The ~3.8 µs per operation matches file-perf's 3-5 µs p50 at `numjobs=1 iodepth=1`. The TCP echo p50 of ~23 µs follows directly: 4 io_uring operations (server read, server write, client read, client write) x ~3.8 µs plus kernel TCP processing overhead.
 
 ### Component costs
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,7 +1,6 @@
 # Synchronization Primitives
 
-All primitives are fiber-aware: waiting suspends the calling fiber rather than
-blocking the OS thread. Source lives in `src/fibers/`.
+All primitives are fiber-aware: waiting suspends the calling fiber rather than blocking the OS thread. Source lives in `src/fibers/`.
 
 ---
 
@@ -18,15 +17,13 @@ FiberSequencer      -- monotone counter with ordered, cancellable waiters
   FairFiberMutex    -- fair (FIFO) mutex (built on FiberSequencer)
 ```
 
-`FiberFuture` is the leaf; every other primitive either uses the scheduler's
-waiter table directly or builds on `FiberSequencer`.
+`FiberFuture` is the leaf; every other primitive either uses the scheduler's waiter table directly or builds on `FiberSequencer`.
 
 ---
 
 ## FiberFuture
 
-Single-producer, single-consumer result handle. The producer calls `set(err)`;
-the consumer calls `wait()` or `isSet()`.
+Single-producer, single-consumer result handle. The producer calls `set(err)`; the consumer calls `wait()` or `isSet()`.
 
 ```cpp
 FiberFuture future;
@@ -38,24 +35,13 @@ int err = future.wait(); // suspends until set
 
 `reset()` clears the future so it can be reused for the next operation.
 
-**State** -- packed `uint64_t`: `{waiter:61, multipleWait:1, hasCallback:1, isSet:1}`.
-The `waiter` field holds a `Fiber*` (normal wait), a `MultipleWaitState*`
-(multiple wait), or a `SubscribeCallback*` (subscribe). The `multipleWait`
-and `hasCallback` bits select the dispatch path in `signal()`; only one is
-ever set on a given future.
+**State** -- packed `uint64_t`: `{waiter:61, multipleWait:1, hasCallback:1, isSet:1}`. The `waiter` field holds a `Fiber*` (normal wait), a `MultipleWaitState*` (multiple wait), or a `SubscribeCallback*` (subscribe). The `multipleWait` and `hasCallback` bits select the dispatch path in `signal()`; only one is ever set on a given future.
 
-**suspendCallback race** -- the waiter pointer is installed inside
-`suspendCallback`, which runs after the fiber is parked. If `signal()` arrives
-between `wait()` reading `isSet=false` and the callback running, the callback
-finds `isSet=true` and reschedules the fiber immediately rather than parking it.
+**suspendCallback race** -- the waiter pointer is installed inside `suspendCallback`, which runs after the fiber is parked. If `signal()` arrives between `wait()` reading `isSet=false` and the callback running, the callback finds `isSet=true` and reschedules the fiber immediately rather than parking it.
 
 ### waitForMultiple
 
-Blocks until at least one future in an array is set. Attaches a
-`MultipleWaitState` (stack-allocated) to each future in order, stopping early
-if one is already set. Once woken, detaches from all futures and spins on a
-`completionCounter` until every in-flight `signal()` has incremented it -- this
-ensures the `MultipleWaitState` on the stack is safe to destroy on return.
+Blocks until at least one future in an array is set. Attaches a `MultipleWaitState` (stack-allocated) to each future in order, stopping early if one is already set. Once woken, detaches from all futures and spins on a `completionCounter` until every in-flight `signal()` has incremented it -- this ensures the `MultipleWaitState` on the stack is safe to destroy on return.
 
 ### waitWithTimeout
 
@@ -64,15 +50,13 @@ int err = FiberFuture::waitWithTimeout(&future, nanoseconds);
 // returns ETIMEDOUT if the deadline expires first
 ```
 
-Implemented as `waitForMultiple` over `{future, sleepFuture}`. Whichever fires
-first wins; the other is cancelled before `waitWithTimeout` returns.
+Implemented as `waitForMultiple` over `{future, sleepFuture}`. Whichever fires first wins; the other is cancelled before `waitWithTimeout` returns.
 
 ---
 
 ## FiberFutex
 
-Counter-based wakeup, mirroring the Linux futex pattern. Multiple fibers may
-wait concurrently; `post()` wakes all of them.
+Counter-based wakeup, mirroring the Linux futex pattern. Multiple fibers may wait concurrently; `post()` wakes all of them.
 
 ```cpp
 FiberFutex futex;
@@ -84,24 +68,17 @@ futex.wait(token + 1);   // or futex.wait() as shorthand for wait(get() + 1)
 futex.post();            // increments counter, wakes all waiters
 ```
 
-**State** -- packed `uint64_t`: `{counter:63, hasWaiters:1}`. `post()` clears
-`hasWaiters` in the same CAS that increments the counter, then calls
-`releaseWaiters` if the old value had the bit set.
+**State** -- packed `uint64_t`: `{counter:63, hasWaiters:1}`. `post()` clears `hasWaiters` in the same CAS that increments the counter, then calls `releaseWaiters` if the old value had the bit set.
 
-**Spin phase** -- 16 PAUSEs (~500 ns) before suspending when no waiters are
-queued, identical strategy to `FiberMutex`.
+**Spin phase** -- 16 PAUSEs (~500 ns) before suspending when no waiters are queued, identical strategy to `FiberMutex`.
 
-**Waiter table** -- uses `FiberScheduler::enqueueWaiter` / `releaseWaiters`
-keyed by `this`. `post()` uses release ordering; `get()` and `wait()` use
-acquire.
+**Waiter table** -- uses `FiberScheduler::enqueueWaiter` / `releaseWaiters` keyed by `this`. `post()` uses release ordering; `get()` and `wait()` use acquire.
 
 ---
 
 ## FiberMutex
 
-Fiber-aware shared mutex. Conforms to `BasicLockable`, `Lockable`, and
-`SharedMutex`; compatible with `std::lock_guard`, `std::unique_lock`, and
-`std::shared_lock`.
+Fiber-aware shared mutex. Conforms to `BasicLockable`, `Lockable`, and `SharedMutex`; compatible with `std::lock_guard`, `std::unique_lock`, and `std::shared_lock`.
 
 ```cpp
 FiberMutex mutex;
@@ -109,58 +86,23 @@ mutex.lock();          /* exclusive */    mutex.unlock();
 mutex.lock_shared();   /* shared */       mutex.unlock_shared();
 ```
 
-**State** -- packed `uint64_t`:
-`{value:61, exclusive:1, hasExclusiveWaiters:1, hasSharedWaiters:1}`.
-The `value` field reinterprets as `Fiber *` when `exclusive=1` and as the
-shared holder count when `exclusive=0`; `raw=0` is the canonical unlocked
-state. Splitting the waiter bit by acquire mode is what enables
-writer-priority: readers can check `hasExclusiveWaiters` on the fast path.
+**State** -- packed `uint64_t`: `{value:61, exclusive:1, hasExclusiveWaiters:1, hasSharedWaiters:1}`. The `value` field reinterprets as `Fiber *` when `exclusive=1` and as the shared holder count when `exclusive=0`; `raw=0` is the canonical unlocked state. Splitting the waiter bit by acquire mode is what enables writer-priority: readers can check `hasExclusiveWaiters` on the fast path.
 
-**Fast path** -- `try_lock()` does a single CAS from 0 to
-`{value=currentFiber, exclusive=1}`. `try_lock_shared()` CASes
-`{value, exclusive=0}` to `{value+1, exclusive=0}` only if
-`hasExclusiveWaiters` is clear.
+**Fast path** -- `try_lock()` does a single CAS from 0 to `{value=currentFiber, exclusive=1}`. `try_lock_shared()` CASes `{value, exclusive=0}` to `{value+1, exclusive=0}` only if `hasExclusiveWaiters` is clear.
 
-**Spin phase** -- `lock()` and `lock_shared()` spin 16 PAUSEs (~500 ns) only
-when the blocker is an identifiable exclusive owner currently `RUNNING` on
-another CPU and no waiter is yet queued. Shared holders have no recorded
-identity, so exclusive acquirers waiting on shared traffic skip the spin
-and go straight to suspend.
+**Spin phase** -- `lock()` and `lock_shared()` spin 16 PAUSEs (~500 ns) only when the blocker is an identifiable exclusive owner currently `RUNNING` on another CPU and no waiter is yet queued. Shared holders have no recorded identity, so exclusive acquirers waiting on shared traffic skip the spin and go straight to suspend.
 
-**Slow path** -- `lockHelper()` arms `hasExclusiveWaiters`;
-`lockSharedHelper()` arms `hasSharedWaiters`. In each case `suspendCallback`
-then enqueues the fiber into the waiter table. `unlock()` CASes state to 0
-and calls `releaseWaiters` if either waiter bit was set. `unlock_shared()`
-decrements `value`; when the count reaches 0 it clears both waiter bits
-atomically and calls `releaseWaiters` if either was set.
+**Slow path** -- `lockHelper()` arms `hasExclusiveWaiters`; `lockSharedHelper()` arms `hasSharedWaiters`. In each case `suspendCallback` then enqueues the fiber into the waiter table. `unlock()` CASes state to 0 and calls `releaseWaiters` if either waiter bit was set. `unlock_shared()` decrements `value`; when the count reaches 0 it clears both waiter bits atomically and calls `releaseWaiters` if either was set.
 
-**Writer priority (best-effort)** -- once an exclusive waiter sets
-`hasExclusiveWaiters`, new readers see the bit on the fast path and queue
-behind the writer rather than slipping in. The wake model is still
-wake-all, so on the next release event every queued waiter races; if a
-shared waiter wins, the writer re-arms the bit and re-suspends. The bit
-is also briefly clear between the release CAS and the writer re-arming it,
-so a reader arriving in that gap can slip ahead. In practice this strongly
-favors writers without providing strict starvation-freedom.
+**Writer priority (best-effort)** -- once an exclusive waiter sets `hasExclusiveWaiters`, new readers see the bit on the fast path and queue behind the writer rather than slipping in. The wake model is still wake-all, so on the next release event every queued waiter races; if a shared waiter wins, the writer re-arms the bit and re-suspends. The bit is also briefly clear between the release CAS and the writer re-arming it, so a reader arriving in that gap can slip ahead. In practice this strongly favors writers without providing strict starvation-freedom.
 
-**suspendCallback race** -- after enqueuing, the waiter re-reads its
-matching bit (`hasExclusiveWaiters` for an exclusive waiter,
-`hasSharedWaiters` for a shared one). If false, the previous releasing
-fiber already called `releaseWaiters` but missed us (we were not yet in
-the waiter table); we self-release. The woken fibers retry their helper
-and either acquire or re-arm the matching bit, and the next release
-delivers them properly.
+**suspendCallback race** -- after enqueuing, the waiter re-reads its matching bit (`hasExclusiveWaiters` for an exclusive waiter, `hasSharedWaiters` for a shared one). If false, the previous releasing fiber already called `releaseWaiters` but missed us (we were not yet in the waiter table); we self-release. The woken fibers retry their helper and either acquire or re-arm the matching bit, and the next release delivers them properly.
 
 ---
 
 ## FiberCondVar
 
-Fiber-aware condition variable. Mirrors `std::condition_variable`: a fiber
-atomically releases a `Lockable` and suspends inside `wait()`; the lock is
-re-acquired before `wait()` returns. `notify_one()` wakes one currently
-waiting fiber (no-op if none is waiting); `notify_all()` wakes everyone
-currently waiting and has no effect on fibers that arrive later. Spurious
-wakeups are permitted -- callers must re-check the predicate.
+Fiber-aware condition variable. Mirrors `std::condition_variable`: a fiber atomically releases a `Lockable` and suspends inside `wait()`; the lock is re-acquired before `wait()` returns. `notify_one()` wakes one currently waiting fiber (no-op if none is waiting); `notify_all()` wakes everyone currently waiting and has no effect on fibers that arrive later. Spurious wakeups are permitted -- callers must re-check the predicate.
 
 ```cpp
 FiberCondVar cv;
@@ -176,34 +118,19 @@ while (!predicate) { cv.wait(lock); }
 cv.notify_one();   // or cv.notify_all()
 ```
 
-`wait` accepts any type with `lock()`/`unlock()`, so it composes with
-`FiberMutex`, `std::unique_lock<FiberMutex>`, etc.
+`wait` accepts any type with `lock()`/`unlock()`, so it composes with `FiberMutex`, `std::unique_lock<FiberMutex>`, etc.
 
-**State** -- a `SpinLock` protects an intrusive `List<Future>` of waiters.
-Each waiter is a `Future` (inherits `FiberFuture`) allocated on the calling
-fiber's stack by `wait()` / `wait_for()` and linked into the list.
+**State** -- a `SpinLock` protects an intrusive `List<Future>` of waiters. Each waiter is a `Future` (inherits `FiberFuture`) allocated on the calling fiber's stack by `wait()` / `wait_for()` and linked into the list.
 
-**wait_for** -- `cv.wait_for(lock, nanoseconds)` returns 0 on a notify-driven
-wakeup or `ETIMEDOUT` on timeout. Implemented via
-`FiberFuture::waitWithTimeout`; on timeout the future cancels itself, which
-removes it from the waiter list. A notify that races at the boundary may
-consume our future but `wait_for` still returns `ETIMEDOUT` -- the
-predicate re-check handles the lost wakeup, per the usual cv contract.
+**wait_for** -- `cv.wait_for(lock, nanoseconds)` returns 0 on a notify-driven wakeup or `ETIMEDOUT` on timeout. Implemented via `FiberFuture::waitWithTimeout`; on timeout the future cancels itself, which removes it from the waiter list. A notify that races at the boundary may consume our future but `wait_for` still returns `ETIMEDOUT` -- the predicate re-check handles the lost wakeup, per the usual cv contract.
 
-**Cancel/notify race** -- a single `inWaiters` bool per waiter, read and
-written only under `spinLock`, serializes timeout-triggered self-cancel
-against `notify_one` / `notify_all`. Exactly one of those paths removes the
-future from the list and calls `set()`; the other observes `inWaiters` is
-false and bails. `notify_all` splices the waiter list into a local snapshot
-and clears `inWaiters` on each, all under the lock; the actual `set(0)`
-calls fire outside the lock.
+**Cancel/notify race** -- a single `inWaiters` bool per waiter, read and written only under `spinLock`, serializes timeout-triggered self-cancel against `notify_one` / `notify_all`. Exactly one of those paths removes the future from the list and calls `set()`; the other observes `inWaiters` is false and bails. `notify_all` splices the waiter list into a local snapshot and clears `inWaiters` on each, all under the lock; the actual `set(0)` calls fire outside the lock.
 
 ---
 
 ## FiberSequencer
 
-Monotone counter with fiber-aware ordered waiters. The foundation for
-`FiberEvent` and `FairFiberMutex`.
+Monotone counter with fiber-aware ordered waiters. The foundation for `FiberEvent` and `FairFiberMutex`.
 
 ```cpp
 FiberSequencer seq;
@@ -217,42 +144,30 @@ seq.increment();           // counter++, wakes all newly satisfied futures
 seq.advance(value);        // CAS counter to value if value > current
 ```
 
-`Future` inherits `FiberFuture`, so it can be passed to
-`FiberFuture::waitForMultiple` and `waitWithTimeout`.
+`Future` inherits `FiberFuture`, so it can be passed to `FiberFuture::waitForMultiple` and `waitWithTimeout`.
 
-**Internal structure** -- three concurrent data structures protected by a
-combiner lock:
+**Internal structure** -- three concurrent data structures protected by a combiner lock:
 
 - `requestQueue` (`LockFreeStack`) -- incoming `Future*` pushed by `wait()`
 - `cancelQueue` (`LockFreeStack`) -- futures pushed by `cancel()`
 - `waiters` (`Tree<Future>`) -- futures inserted by the combiner, sorted by token
 
-**Combiner pattern** -- `drain()` is called after every `increment()`,
-`advance()`, and `cancel()`. Only one thread runs it at a time; others CAS the
-combiner state to `PENDING` and return. The active combiner loops until it can
-transition from `BUSY` back to `FREE` without seeing `PENDING`, meaning no new
-work arrived during its pass.
+**Combiner pattern** -- `drain()` is called after every `increment()`, `advance()`, and `cancel()`. Only one thread runs it at a time; others CAS the combiner state to `PENDING` and return. The active combiner loops until it can transition from `BUSY` back to `FREE` without seeing `PENDING`, meaning no new work arrived during its pass.
 
 Inside the combiner:
 1. Drain `cancelQueue`: remove each future from the tree, add to cancel list.
-2. Drain `requestQueue`: classify each future -- if `CANCELLED` raced ahead,
-   add to cancel list; otherwise insert into the tree.
+2. Drain `requestQueue`: classify each future -- if `CANCELLED` raced ahead, add to cancel list; otherwise insert into the tree.
 3. Walk the tree from the minimum: wake all futures whose `token <= counter`.
 
-Wakes and cancels are deferred until after the combiner is released, so
-`future.set()` can itself call `drain()` without deadlocking.
+Wakes and cancels are deferred until after the combiner is released, so `future.set()` can itself call `drain()` without deadlocking.
 
-**Cancellation state** -- `Future::state` has two bits: `IN_TABLE` (set by the
-combiner when inserting into the tree) and `CANCELLED` (set by `cancel()`).
-The `IN_TABLE` bit ensures `cancelQueue` holds the future only while it is in
-the tree, mirroring the sleep cancellation pattern in the scheduler.
+**Cancellation state** -- `Future::state` has two bits: `IN_TABLE` (set by the combiner when inserting into the tree) and `CANCELLED` (set by `cancel()`). The `IN_TABLE` bit ensures `cancelQueue` holds the future only while it is in the tree, mirroring the sleep cancellation pattern in the scheduler.
 
 ---
 
 ## FiberEvent
 
-Manual-reset event built on `FiberSequencer`. The event is either set or unset;
-`set()` wakes all current waiters and the event stays set until `reset()`.
+Manual-reset event built on `FiberSequencer`. The event is either set or unset; `set()` wakes all current waiters and the event stays set until `reset()`.
 
 ```cpp
 FiberEvent event;
@@ -265,21 +180,18 @@ event.set();
 event.reset();
 ```
 
-**Implementation** -- maps the set/unset state onto the sequencer counter's
-LSB: odd = set, even = unset.
+**Implementation** -- maps the set/unset state onto the sequencer counter's LSB: odd = set, even = unset.
 
 - `isSet()`: `counter & 1`
 - `set()`: `advance(counter | 1)` -- no-op if already odd
-- `reset()`: `advance(counter + (counter & 1))` -- increments by 1 only if odd,
-  making it even
+- `reset()`: `advance(counter + (counter & 1))` -- increments by 1 only if odd, making it even
 - `wait()`: waits for the next odd value (`counter + 1` if currently even)
 
 ---
 
 ## FairFiberMutex
 
-Fair (FIFO) mutex implemented as a ticket lock over `FiberSequencer`. Conforms
-to `BasicLockable`; compatible with `std::lock_guard`.
+Fair (FIFO) mutex implemented as a ticket lock over `FiberSequencer`. Conforms to `BasicLockable`; compatible with `std::lock_guard`.
 
 ```cpp
 FairFiberMutex mutex;
@@ -290,12 +202,6 @@ FairFiberMutex::Future future;
 mutex.lock(&future);  // takes a ticket, returns immediately; caller waits on future
 ```
 
-**Implementation** -- `nextTicket` is the issue counter; the sequencer counter
-is the serve counter. `lock()` does `fetch_add(1)` on `nextTicket` to claim a
-ticket, then calls `sequencer.wait(ticket)` to block until that ticket is
-served. `unlock()` calls `sequencer.increment()`, which advances the serve
-counter by one and wakes the next waiter in token order.
+**Implementation** -- `nextTicket` is the issue counter; the sequencer counter is the serve counter. `lock()` does `fetch_add(1)` on `nextTicket` to claim a ticket, then calls `sequencer.wait(ticket)` to block until that ticket is served. `unlock()` calls `sequencer.increment()`, which advances the serve counter by one and wakes the next waiter in token order.
 
-The async `lock(Future*)` variant is useful when the caller needs to signal
-readiness after taking a ticket but before actually blocking -- for example, to
-post a message to another fiber confirming the lock request is queued.
+The async `lock(Future*)` variant is useful when the caller needs to signal readiness after taking a ticket but before actually blocking -- for example, to post a message to another fiber confirming the lock request is queued.

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,0 +1,178 @@
+# Thread-Local Storage and Fibers
+
+## Overview
+
+silk fibers are stackful coroutines that migrate between OS threads: a fiber can
+suspend on one scheduler thread and resume on another (work-stealing, the
+SQ-ring-overflow `yield` in `enqueueIo`, ready-queue overflow to the worker
+pool, thread mode). Native thread-local storage assumes the opposite, that a
+function runs on one fixed thread for its whole duration. That mismatch makes
+ordinary `thread_local` access unsafe in fiber code unless you follow the rules
+below.
+
+This is not a silk bug you can fully fix from inside the library: it affects any
+code that runs on a fiber and reads a `thread_local`, including the host
+application and libc. silk hardens its own context accessors (see below) and
+documents the rules so callers can stay correct.
+
+## Why it is dangerous
+
+A `thread_local` access is "thread pointer + offset". The thread pointer lives
+in a fixed register (`%fs` base on x86-64, `TPIDR_EL0` on aarch64). The C++
+abstract machine guarantees a thread-local's address is stable for the lifetime
+of the thread, so the compiler is free to read the thread pointer once,
+materialize it into a callee-saved register, and reuse it across function calls
+and loop iterations.
+
+Fibers break that guarantee. When a fiber suspends, `switchToThreadContext`
+calls `jump_fcontext`, which saves the fiber's callee-saved registers as part of
+its context and restores them when the fiber resumes. If the fiber resumes on a
+**different** OS thread, the restored registers still hold the **original**
+thread's thread pointer. Every subsequent thread-local read in that function
+then addresses the previous (now idle) thread's storage, returning a stale value
+or null.
+
+There is no compiler flag to disable this on GCC or Clang. MSVC has `/GT`
+("fiber-safe TLS") for exactly this case; the GNU toolchain has no equivalent
+(see GCC PR 26461). The hazard is latent at low optimization and becomes live
+with more inlining, and especially with unity builds and LTO, which inline the
+small TLS accessors into more call sites where the thread pointer can be hoisted
+across a suspension. Crashes that "cannot happen" by reading the source are the
+usual symptom.
+
+## The single migration point
+
+All fiber-to-thread migration funnels through `FiberScheduler::suspend`
+(`switchToThreadContext` then `jump_fcontext`). User code reaches it indirectly
+through any call that can suspend:
+
+- `FiberScheduler::yield`
+- `FiberScheduler::read`, `write`, `poll`, `sleep`
+- `FiberFuture::wait`, `waitWithTimeout`, `waitForMultiple`
+- `FiberMutex::lock`, `FiberFutex::wait`, and the other synchronization
+  primitives in `docs/sync.md`
+
+Treat every such call as a point where the current OS thread, the current CPU
+index, and the value of any `thread_local` may change underneath you.
+
+## Symptoms
+
+- A stale read of a thread-local pointer dereferenced as null: a `SIGSEGV` at a
+  tiny fixed address equal to a struct field offset. The canonical instance was
+  `getCurrentFiber` returning null and the caller reading `Fiber::isProxyFiber`
+  at address `0x9` (the field's offset in a null `Fiber`).
+- A stale `getCurrentProcessor`: IO submitted to the wrong CPU's io_uring ring,
+  which is single-producer, so a data race and ring corruption.
+- Behavior that changes with optimization level, inlining, unity build, or LTO.
+
+## Rules for fiber code
+
+### Safe: read migration-invariant data once
+
+A fiber's identity does not change across migration. A `Fiber *` from
+`getCurrentFiber` refers to the same fiber regardless of which thread runs it, so
+reading it once before a suspension and using the value afterwards is correct.
+`enqueueIo`, for example, may read the running fiber once before its retry loop.
+
+### Unsafe: caching a thread-affine value or a TLS address across a suspension
+
+Do not hold any of these across a call that can suspend:
+
+- the thread pointer (`__builtin_thread_pointer`, or `getCurrentProcessor`'s rseq
+  read),
+- the address of a `thread_local`,
+- a value that is meaningful only on the thread you read it on: the current CPU
+  index, `errno`, a per-thread cache pointer, or the host application's own
+  thread-locals (for example a current-thread or memory-accounting pointer).
+
+Re-read it after the suspension instead. Note that re-reading the host
+application's per-thread state is a correctness question beyond compilation: if a
+fiber accounts memory against thread A then migrates to thread B, even a
+perfectly fresh read attributes later work to B. Code with hard per-thread
+affinity should not run on a migrating fiber, or should pin.
+
+### `errno` is a trap
+
+`errno` expands to `*__errno_location()`, and glibc marks `__errno_location`
+`__attribute__((const))`, so the compiler caches the returned address very
+aggressively, including across opaque calls. Read `errno` into a local
+immediately after the syscall that set it, before any suspension, and never read
+`errno` after a suspension expecting the syscall's value:
+
+```cpp
+ssize_t n = ::send(fd, buf, len, MSG_NOSIGNAL);
+int err = errno;          // capture before any poll()/suspension
+if (n < 0 && (err == EAGAIN || err == EWOULDBLOCK))
+{
+    poll(...);            // suspension: errno is now meaningless to us
+    continue;
+}
+```
+
+### `thread_local volatile` does not help
+
+`volatile` forces the value access to be performed; it does not force the address
+(the thread pointer) to be recomputed. The compiler still reuses a thread pointer
+it has already cached, so a `volatile` thread-local read after a migration is
+just as stale. Do not rely on it.
+
+### What actually triggers the caching
+
+A single `thread_local` scalar read compiles to thread-pointer-relative
+addressing (`%fs:var@TPOFF`, or `TPIDR_EL0`-relative), which re-reads the thread
+pointer on every access and is therefore safe even across a suspension. The
+compiler materializes and caches the thread pointer in a callee-saved register
+when:
+
+- the address of a `thread_local` escapes to a function. A `thread_local` with a
+  non-trivial destructor registers it via `__cxa_thread_atexit`, which takes its
+  address.
+- several thread-locals are accessed together,
+- a thread-local is accessed inside a loop,
+- you call `__builtin_thread_pointer` explicitly.
+
+These are exactly the shapes that occur in hot fiber code, which is why the
+hazard is real rather than theoretical.
+
+## How silk makes its own context accessors safe
+
+- `getCurrentProcessor` (`include/silk/util/platform.h`) reads the thread pointer
+  through volatile asm (`movq %fs:0` on x86-64, `mrs ..., tpidr_el0` on aarch64)
+  rather than `__builtin_thread_pointer`. Volatile asm cannot be hoisted out of a
+  loop or CSE'd across a call, so the rseq CPU index is always read against the
+  current thread.
+- `getCurrentFiber` and `getCurrentFiberId` (`src/fibers/fiber.cpp`) are
+  `__attribute__((noinline))`. Their `threadFiber` and `proxyFiber` reads happen
+  in a fresh call activation on whichever thread is currently running the fiber,
+  regardless of how aggressively the caller is inlined, including under unity
+  builds and LTO. The `noinline` is load-bearing, not a hint.
+- `runFiber`'s `threadFiber = fiber` and `threadFiber = nullptr` writes are
+  deliberately left as direct accesses: `runFiber` executes on a single scheduler
+  thread that does not migrate, and `switchToFiberContext` returns on that same
+  thread. The fiber migrates, the scheduler thread does not.
+
+If you add a `thread_local` to silk that fiber code reads across a suspension,
+apply the same treatment: read its address only through a `noinline` accessor, or
+read the thread pointer through `getCurrentProcessor`'s volatile-asm pattern.
+
+## Diagnosing a suspected TLS-migration bug
+
+- A `SIGSEGV` at a tiny fixed address (a struct field offset) inside a
+  thread-local accessor such as `getCurrentFiber` is the signature.
+- Disassemble the function. A thread pointer read (`mov %fs:0, %rN`, or
+  `mrs xN, tpidr_el0`) hoisted before a loop or a suspending call and then reused
+  through a callee-saved register afterwards is the bug. A fixed accessor re-reads
+  the thread pointer after the suspension.
+- It reproduces under load: many IO-bound fibers on a small CPU set so that the
+  `enqueueIo` SQ-ring-overflow `yield` fires and work-stealing migrates a
+  resuming fiber. It may disappear at lower optimization or with the accessor not
+  inlined.
+
+## References
+
+- GCC PR 26461, "optimisation of TLS access" / request for an option to disable
+  caching of `__thread` addresses.
+- gcc@ mailing list thread, "Disabling TLS address caching to help QEMU on
+  GNU/Linux".
+- MSVC `/GT`, "Supports fiber safety for data allocated by using static
+  thread-local storage", the compiler switch the GNU toolchain lacks.

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -2,102 +2,54 @@
 
 ## Overview
 
-silk fibers are stackful coroutines that migrate between OS threads: a fiber can
-suspend on one scheduler thread and resume on another (work-stealing, the
-SQ-ring-overflow `yield` in `enqueueIo`, ready-queue overflow to the worker
-pool, thread mode). Native thread-local storage assumes the opposite, that a
-function runs on one fixed thread for its whole duration. That mismatch makes
-ordinary `thread_local` access unsafe in fiber code unless you follow the rules
-below.
+silk fibers are stackful coroutines that migrate between OS threads: a fiber can suspend on one scheduler thread and resume on another (work-stealing, the SQ-ring-overflow `yield` in `enqueueIo`, ready-queue overflow to the worker pool, thread mode). Native thread-local storage assumes the opposite, that a function runs on one fixed thread for its whole duration. That mismatch makes ordinary `thread_local` access unsafe in fiber code unless you follow the rules below.
 
-This is not a silk bug you can fully fix from inside the library: it affects any
-code that runs on a fiber and reads a `thread_local`, including the host
-application and libc. silk hardens its own context accessors (see below) and
-documents the rules so callers can stay correct.
+This is not a silk bug you can fully fix from inside the library: it affects any code that runs on a fiber and reads a `thread_local`, including the host application and libc. silk hardens its own context accessors (see below) and documents the rules so callers can stay correct.
 
 ## Why it is dangerous
 
-A `thread_local` access is "thread pointer + offset". The thread pointer lives
-in a fixed register (`%fs` base on x86-64, `TPIDR_EL0` on aarch64). The C++
-abstract machine guarantees a thread-local's address is stable for the lifetime
-of the thread, so the compiler is free to read the thread pointer once,
-materialize it into a callee-saved register, and reuse it across function calls
-and loop iterations.
+A `thread_local` access is "thread pointer + offset". The thread pointer lives in a fixed register (`%fs` base on x86-64, `TPIDR_EL0` on aarch64). The C++ abstract machine guarantees a thread-local's address is stable for the lifetime of the thread, so the compiler is free to read the thread pointer once, materialize it into a callee-saved register, and reuse it across function calls and loop iterations.
 
-Fibers break that guarantee. When a fiber suspends, `switchToThreadContext`
-calls `jump_fcontext`, which saves the fiber's callee-saved registers as part of
-its context and restores them when the fiber resumes. If the fiber resumes on a
-**different** OS thread, the restored registers still hold the **original**
-thread's thread pointer. Every subsequent thread-local read in that function
-then addresses the previous (now idle) thread's storage, returning a stale value
-or null.
+Fibers break that guarantee. When a fiber suspends, `switchToThreadContext` calls `jump_fcontext`, which saves the fiber's callee-saved registers as part of its context and restores them when the fiber resumes. If the fiber resumes on a **different** OS thread, the restored registers still hold the **original** thread's thread pointer. Every subsequent thread-local read in that function then addresses the previous (now idle) thread's storage, returning a stale value or null.
 
-There is no compiler flag to disable this on GCC or Clang. MSVC has `/GT`
-("fiber-safe TLS") for exactly this case; the GNU toolchain has no equivalent
-(see GCC PR 26461). The hazard is latent at low optimization and becomes live
-with more inlining, and especially with unity builds and LTO, which inline the
-small TLS accessors into more call sites where the thread pointer can be hoisted
-across a suspension. Crashes that "cannot happen" by reading the source are the
-usual symptom.
+There is no compiler flag to disable this on GCC or Clang. MSVC has `/GT` ("fiber-safe TLS") for exactly this case; the GNU toolchain has no equivalent (see GCC PR 26461). The hazard is latent at low optimization and becomes live with more inlining, and especially with unity builds and LTO, which inline the small TLS accessors into more call sites where the thread pointer can be hoisted across a suspension. Crashes that "cannot happen" by reading the source are the usual symptom.
 
 ## The single migration point
 
-All fiber-to-thread migration funnels through `FiberScheduler::suspend`
-(`switchToThreadContext` then `jump_fcontext`). User code reaches it indirectly
-through any call that can suspend:
+All fiber-to-thread migration funnels through `FiberScheduler::suspend` (`switchToThreadContext` then `jump_fcontext`). User code reaches it indirectly through any call that can suspend:
 
 - `FiberScheduler::yield`
 - `FiberScheduler::read`, `write`, `poll`, `sleep`
 - `FiberFuture::wait`, `waitWithTimeout`, `waitForMultiple`
-- `FiberMutex::lock`, `FiberFutex::wait`, and the other synchronization
-  primitives in `docs/sync.md`
+- `FiberMutex::lock`, `FiberFutex::wait`, and the other synchronization primitives in `docs/sync.md`
 
-Treat every such call as a point where the current OS thread, the current CPU
-index, and the value of any `thread_local` may change underneath you.
+Treat every such call as a point where the current OS thread, the current CPU index, and the value of any `thread_local` may change underneath you.
 
 ## Symptoms
 
-- A stale read of a thread-local pointer dereferenced as null: a `SIGSEGV` at a
-  tiny fixed address equal to a struct field offset. The canonical instance was
-  `getCurrentFiber` returning null and the caller reading `Fiber::isProxyFiber`
-  at address `0x9` (the field's offset in a null `Fiber`).
-- A stale `getCurrentProcessor`: IO submitted to the wrong CPU's io_uring ring,
-  which is single-producer, so a data race and ring corruption.
+- A stale read of a thread-local pointer dereferenced as null: a `SIGSEGV` at a tiny fixed address equal to a struct field offset. The canonical instance was `getCurrentFiber` returning null and the caller reading `Fiber::isProxyFiber` at address `0x9` (the field's offset in a null `Fiber`).
+- A stale `getCurrentProcessor`: IO submitted to the wrong CPU's io_uring ring, which is single-producer, so a data race and ring corruption.
 - Behavior that changes with optimization level, inlining, unity build, or LTO.
 
 ## Rules for fiber code
 
 ### Safe: read migration-invariant data once
 
-A fiber's identity does not change across migration. A `Fiber *` from
-`getCurrentFiber` refers to the same fiber regardless of which thread runs it, so
-reading it once before a suspension and using the value afterwards is correct.
-`enqueueIo`, for example, may read the running fiber once before its retry loop.
+A fiber's identity does not change across migration. A `Fiber *` from `getCurrentFiber` refers to the same fiber regardless of which thread runs it, so reading it once before a suspension and using the value afterwards is correct. `enqueueIo`, for example, may read the running fiber once before its retry loop.
 
 ### Unsafe: caching a thread-affine value or a TLS address across a suspension
 
 Do not hold any of these across a call that can suspend:
 
-- the thread pointer (`__builtin_thread_pointer`, or `getCurrentProcessor`'s rseq
-  read),
+- the thread pointer (`__builtin_thread_pointer`, or `getCurrentProcessor`'s rseq read),
 - the address of a `thread_local`,
-- a value that is meaningful only on the thread you read it on: the current CPU
-  index, `errno`, a per-thread cache pointer, or the host application's own
-  thread-locals (for example a current-thread or memory-accounting pointer).
+- a value that is meaningful only on the thread you read it on: the current CPU index, `errno`, a per-thread cache pointer, or the host application's own thread-locals (for example a current-thread or memory-accounting pointer).
 
-Re-read it after the suspension instead. Note that re-reading the host
-application's per-thread state is a correctness question beyond compilation: if a
-fiber accounts memory against thread A then migrates to thread B, even a
-perfectly fresh read attributes later work to B. Code with hard per-thread
-affinity should not run on a migrating fiber, or should pin.
+Re-read it after the suspension instead. Note that re-reading the host application's per-thread state is a correctness question beyond compilation: if a fiber accounts memory against thread A then migrates to thread B, even a perfectly fresh read attributes later work to B. Code with hard per-thread affinity should not run on a migrating fiber, or should pin.
 
 ### `errno` is a trap
 
-`errno` expands to `*__errno_location()`, and glibc marks `__errno_location`
-`__attribute__((const))`, so the compiler caches the returned address very
-aggressively, including across opaque calls. Read `errno` into a local
-immediately after the syscall that set it, before any suspension, and never read
-`errno` after a suspension expecting the syscall's value:
+`errno` expands to `*__errno_location()`, and glibc marks `__errno_location` `__attribute__((const))`, so the compiler caches the returned address very aggressively, including across opaque calls. Read `errno` into a local immediately after the syscall that set it, before any suspension, and never read `errno` after a suspension expecting the syscall's value:
 
 ```cpp
 ssize_t n = ::send(fd, buf, len, MSG_NOSIGNAL);
@@ -111,68 +63,35 @@ if (n < 0 && (err == EAGAIN || err == EWOULDBLOCK))
 
 ### `thread_local volatile` does not help
 
-`volatile` forces the value access to be performed; it does not force the address
-(the thread pointer) to be recomputed. The compiler still reuses a thread pointer
-it has already cached, so a `volatile` thread-local read after a migration is
-just as stale. Do not rely on it.
+`volatile` forces the value access to be performed; it does not force the address (the thread pointer) to be recomputed. The compiler still reuses a thread pointer it has already cached, so a `volatile` thread-local read after a migration is just as stale. Do not rely on it.
 
 ### What actually triggers the caching
 
-A single `thread_local` scalar read compiles to thread-pointer-relative
-addressing (`%fs:var@TPOFF`, or `TPIDR_EL0`-relative), which re-reads the thread
-pointer on every access and is therefore safe even across a suspension. The
-compiler materializes and caches the thread pointer in a callee-saved register
-when:
+A single `thread_local` scalar read compiles to thread-pointer-relative addressing (`%fs:var@TPOFF`, or `TPIDR_EL0`-relative), which re-reads the thread pointer on every access and is therefore safe even across a suspension. The compiler materializes and caches the thread pointer in a callee-saved register when:
 
-- the address of a `thread_local` escapes to a function. A `thread_local` with a
-  non-trivial destructor registers it via `__cxa_thread_atexit`, which takes its
-  address.
+- the address of a `thread_local` escapes to a function. A `thread_local` with a non-trivial destructor registers it via `__cxa_thread_atexit`, which takes its address.
 - several thread-locals are accessed together,
 - a thread-local is accessed inside a loop,
 - you call `__builtin_thread_pointer` explicitly.
 
-These are exactly the shapes that occur in hot fiber code, which is why the
-hazard is real rather than theoretical.
+These are exactly the shapes that occur in hot fiber code, which is why the hazard is real rather than theoretical.
 
 ## How silk makes its own context accessors safe
 
-- `getCurrentProcessor` (`include/silk/util/platform.h`) reads the thread pointer
-  through volatile asm (`movq %fs:0` on x86-64, `mrs ..., tpidr_el0` on aarch64)
-  rather than `__builtin_thread_pointer`. Volatile asm cannot be hoisted out of a
-  loop or CSE'd across a call, so the rseq CPU index is always read against the
-  current thread.
-- `getCurrentFiber` and `getCurrentFiberId` (`src/fibers/fiber.cpp`) are
-  `__attribute__((noinline))`. Their `threadFiber` and `proxyFiber` reads happen
-  in a fresh call activation on whichever thread is currently running the fiber,
-  regardless of how aggressively the caller is inlined, including under unity
-  builds and LTO. The `noinline` is load-bearing, not a hint.
-- `runFiber`'s `threadFiber = fiber` and `threadFiber = nullptr` writes are
-  deliberately left as direct accesses: `runFiber` executes on a single scheduler
-  thread that does not migrate, and `switchToFiberContext` returns on that same
-  thread. The fiber migrates, the scheduler thread does not.
+- `getCurrentProcessor` (`include/silk/util/platform.h`) reads the thread pointer through volatile asm (`movq %fs:0` on x86-64, `mrs ..., tpidr_el0` on aarch64) rather than `__builtin_thread_pointer`. Volatile asm cannot be hoisted out of a loop or CSE'd across a call, so the rseq CPU index is always read against the current thread.
+- `getCurrentFiber` and `getCurrentFiberId` (`src/fibers/fiber.cpp`) are `__attribute__((noinline))`. Their `threadFiber` and `proxyFiber` reads happen in a fresh call activation on whichever thread is currently running the fiber, regardless of how aggressively the caller is inlined, including under unity builds and LTO. The `noinline` is load-bearing, not a hint.
+- `runFiber`'s `threadFiber = fiber` and `threadFiber = nullptr` writes are deliberately left as direct accesses: `runFiber` executes on a single scheduler thread that does not migrate, and `switchToFiberContext` returns on that same thread. The fiber migrates, the scheduler thread does not.
 
-If you add a `thread_local` to silk that fiber code reads across a suspension,
-apply the same treatment: read its address only through a `noinline` accessor, or
-read the thread pointer through `getCurrentProcessor`'s volatile-asm pattern.
+If you add a `thread_local` to silk that fiber code reads across a suspension, apply the same treatment: read its address only through a `noinline` accessor, or read the thread pointer through `getCurrentProcessor`'s volatile-asm pattern.
 
 ## Diagnosing a suspected TLS-migration bug
 
-- A `SIGSEGV` at a tiny fixed address (a struct field offset) inside a
-  thread-local accessor such as `getCurrentFiber` is the signature.
-- Disassemble the function. A thread pointer read (`mov %fs:0, %rN`, or
-  `mrs xN, tpidr_el0`) hoisted before a loop or a suspending call and then reused
-  through a callee-saved register afterwards is the bug. A fixed accessor re-reads
-  the thread pointer after the suspension.
-- It reproduces under load: many IO-bound fibers on a small CPU set so that the
-  `enqueueIo` SQ-ring-overflow `yield` fires and work-stealing migrates a
-  resuming fiber. It may disappear at lower optimization or with the accessor not
-  inlined.
+- A `SIGSEGV` at a tiny fixed address (a struct field offset) inside a thread-local accessor such as `getCurrentFiber` is the signature.
+- Disassemble the function. A thread pointer read (`mov %fs:0, %rN`, or `mrs xN, tpidr_el0`) hoisted before a loop or a suspending call and then reused through a callee-saved register afterwards is the bug. A fixed accessor re-reads the thread pointer after the suspension.
+- It reproduces under load: many IO-bound fibers on a small CPU set so that the `enqueueIo` SQ-ring-overflow `yield` fires and work-stealing migrates a resuming fiber. It may disappear at lower optimization or with the accessor not inlined.
 
 ## References
 
-- GCC PR 26461, "optimisation of TLS access" / request for an option to disable
-  caching of `__thread` addresses.
-- gcc@ mailing list thread, "Disabling TLS address caching to help QEMU on
-  GNU/Linux".
-- MSVC `/GT`, "Supports fiber safety for data allocated by using static
-  thread-local storage", the compiler switch the GNU toolchain lacks.
+- GCC PR 26461, "optimisation of TLS access" / request for an option to disable caching of `__thread` addresses.
+- gcc@ mailing list thread, "Disabling TLS address caching to help QEMU on GNU/Linux".
+- MSVC `/GT`, "Supports fiber safety for data allocated by using static thread-local storage", the compiler switch the GNU toolchain lacks.

--- a/docs/util.md
+++ b/docs/util.md
@@ -1,7 +1,6 @@
 # Utility Library
 
-All utilities live in `src/util/`. They are used by the fiber scheduler and its
-synchronization primitives but have no dependency on them.
+All utilities live in `src/util/`. They are used by the fiber scheduler and its synchronization primitives but have no dependency on them.
 
 ---
 
@@ -20,22 +19,15 @@ Cross-platform constants and thin OS wrappers.
 | `cpuPause()` | CPU pause hint for spin loops |
 | `getTimeNanoseconds()` | Monotonic clock in nanoseconds (`CLOCK_MONOTONIC`) |
 
-**`cpuPause()`** emits `PAUSE` on x86-64 and `ISB` on aarch64. `ISB` is used
-instead of `YIELD` because `YIELD` is a NOP on non-SMT Graviton cores, providing
-no backoff. `ISB` flushes the pipeline and takes ~13 ns, equivalent to x86
-`PAUSE`.
+**`cpuPause()`** emits `PAUSE` on x86-64 and `ISB` on aarch64. `ISB` is used instead of `YIELD` because `YIELD` is a NOP on non-SMT Graviton cores, providing no backoff. `ISB` flushes the pipeline and takes ~13 ns, equivalent to x86 `PAUSE`.
 
-**Prefer `Tsc::getCycles()` over `getTimeNanoseconds()`** for hot-path timing.
-`getTimeNanoseconds()` calls `clock_gettime` (a syscall on some kernels); `Tsc`
-is a single instruction with no syscall overhead.
+**Prefer `Tsc::getCycles()` over `getTimeNanoseconds()`** for hot-path timing. `getTimeNanoseconds()` calls `clock_gettime` (a syscall on some kernels); `Tsc` is a single instruction with no syscall overhead.
 
 ---
 
 ## TSC (`tsc.h`)
 
-Reads the CPU timestamp counter and converts between cycles and nanoseconds.
-Frequency is detected once at startup and cached; conversions use
-fixed-point multiply-shift (`cycles * fp >> 20`) with no division.
+Reads the CPU timestamp counter and converts between cycles and nanoseconds. Frequency is detected once at startup and cached; conversions use fixed-point multiply-shift (`cycles * fp >> 20`) with no division.
 
 ```cpp
 uint64_t start = Tsc::getCycles();
@@ -45,10 +37,7 @@ uint64_t elapsed = Tsc::cyclesToNanoseconds(Tsc::getCycles() - start);
 uint64_t deadline = Tsc::getCycles() + Tsc::nanosecondsToCycles(1'000'000); // 1 ms
 ```
 
-**`getCycles()`** is `rdtsc` on x86-64 and `cntvct_el0` on aarch64. No
-serializing barrier is issued; instruction reordering is not a concern for
-deadline calculation. For precise interval measurement, bracket the reads with
-`lfence`.
+**`getCycles()`** is `rdtsc` on x86-64 and `cntvct_el0` on aarch64. No serializing barrier is issued; instruction reordering is not a concern for deadline calculation. For precise interval measurement, bracket the reads with `lfence`.
 
 **Frequency detection** (x86-64, in order):
 1. KVM hypervisor leaf `0x40000010` EAX (kHz) -- AWS Nitro, GCP
@@ -61,25 +50,17 @@ On aarch64, frequency comes from `cntfrq_el0`.
 
 ## Spin Utilities (`spinlock.h`)
 
-**`spinWait(pred, count = 64)`** -- spins up to `count` iterations calling
-`cpuPause()` and checking `pred` after each. Returns `true` if `pred` returned
-`true`, `false` if the limit was exhausted. Default 64 iterations covers ~2 us
-on Skylake, roughly one OS context-switch latency.
+**`spinWait(pred, count = 64)`** -- spins up to `count` iterations calling `cpuPause()` and checking `pred` after each. Returns `true` if `pred` returned `true`, `false` if the limit was exhausted. Default 64 iterations covers ~2 us on Skylake, roughly one OS context-switch latency.
 
-**`SpinLock`** -- test-and-set spinlock with two-phase backoff: spin with
-`cpuPause()` for `SPIN_COUNT` iterations, then fall back to `schedYield()` and
-repeat. Conforms to `BasicLockable`. Used where fiber-aware suspension is not
-available (e.g. inside `MemoryPool`).
+**`SpinLock`** -- test-and-set spinlock with two-phase backoff: spin with `cpuPause()` for `SPIN_COUNT` iterations, then fall back to `schedYield()` and repeat. Conforms to `BasicLockable`. Used where fiber-aware suspension is not available (e.g. inside `MemoryPool`).
 
 ---
 
 ## LockFreeStack (`stack.h`)
 
-Lock-free intrusive LIFO stack. ABA-safe via 128-bit tagged pointer
-(`CMPXCHG16B` on x86-64, `CASP LSE` on aarch64).
+Lock-free intrusive LIFO stack. ABA-safe via 128-bit tagged pointer (`CMPXCHG16B` on x86-64, `CASP LSE` on aarch64).
 
-Objects must embed a `StackEntry` member. The typed wrapper takes a
-member pointer at compile time and handles object/entry conversion.
+Objects must embed a `StackEntry` member. The typed wrapper takes a member pointer at compile time and handles object/entry conversion.
 
 ```cpp
 struct MyNode {
@@ -98,22 +79,15 @@ while (list) {
 }
 ```
 
-`popAll()` detaches the entire chain atomically. Iteration uses the static
-`next()` helper to follow `stackEntry.next` pointers.
+`popAll()` detaches the entire chain atomically. Iteration uses the static `next()` helper to follow `stackEntry.next` pointers.
 
 ---
 
 ## ShardedStack (`sharded-stack.h`)
 
-Per-CPU intrusive LIFO stack backed by restartable sequences (rseq). The fast
-path (push/pop when the per-CPU list is non-empty/non-full) executes zero atomic
-instructions. The kernel aborts and restarts the rseq critical section on
-preemption or migration, so plain loads/stores suffice for per-CPU state. The
-slow path transfers a full batch to/from a global pool via a single 128-bit CAS,
-amortising its cost over `batchSize` operations.
+Per-CPU intrusive LIFO stack backed by restartable sequences (rseq). The fast path (push/pop when the per-CPU list is non-empty/non-full) executes zero atomic instructions. The kernel aborts and restarts the rseq critical section on preemption or migration, so plain loads/stores suffice for per-CPU state. The slow path transfers a full batch to/from a global pool via a single 128-bit CAS, amortising its cost over `batchSize` operations.
 
-Objects must embed a `StackEntry` member; the typed wrapper `ShardedStack` takes
-a member pointer as a template argument.
+Objects must embed a `StackEntry` member; the typed wrapper `ShardedStack` takes a member pointer as a template argument.
 
 ```cpp
 struct MyNode {
@@ -138,16 +112,13 @@ stack.flush();               // move per-CPU buffers to the global pool
 | 16 | 5.53 | 6092 | 1101x |
 | 32 | 10.7 | 22123 | 2068x |
 
-`ShardedStack` stays below 6 ns up to 16 threads; `LockFreeStack` degrades
-rapidly because every operation issues a `CMPXCHG16B` that bounces the cache
-line across all contending CPUs.
+`ShardedStack` stays below 6 ns up to 16 threads; `LockFreeStack` degrades rapidly because every operation issues a `CMPXCHG16B` that bounces the cache line across all contending CPUs.
 
 ---
 
 ## Queue (`queue.h`)
 
-Lock-free MPMC FIFO queue (Michael & Scott algorithm). Not intrusive -- nodes
-are allocated from a shared `MemoryPool<QueueNode>` and store a `void*` value.
+Lock-free MPMC FIFO queue (Michael & Scott algorithm). Not intrusive -- nodes are allocated from a shared `MemoryPool<QueueNode>` and store a `void*` value.
 
 ```cpp
 Queue<MyObject> queue;
@@ -155,16 +126,13 @@ queue.enqueue(&obj);
 MyObject * obj = queue.dequeue(); // nullptr if empty
 ```
 
-`empty()` is a relaxed check and may transiently return `true` during a
-concurrent enqueue. Use it as a hint only.
+`empty()` is a relaxed check and may transiently return `true` during a concurrent enqueue. Use it as a hint only.
 
 ---
 
 ## BoundedQueue (`bounded-queue.h`)
 
-Bounded lock-free MPMC FIFO queue (Dmitry Vyukov sequence-number algorithm).
-Capacity is fixed at construction and must be a power of two. Slots are
-heap-allocated once; no per-operation allocation.
+Bounded lock-free MPMC FIFO queue (Dmitry Vyukov sequence-number algorithm). Capacity is fixed at construction and must be a power of two. Slots are heap-allocated once; no per-operation allocation.
 
 ```cpp
 BoundedQueue<Fiber *> readyQueue(1024);
@@ -173,19 +141,15 @@ Fiber * fiber;
 bool ok = readyQueue.dequeue(&fiber); // false if empty
 ```
 
-Slots are cache-line aligned to prevent false sharing between the enqueue and
-dequeue positions. Used for the per-CPU ready queue in the fiber scheduler.
+Slots are cache-line aligned to prevent false sharing between the enqueue and dequeue positions. Used for the per-CPU ready queue in the fiber scheduler.
 
 ---
 
 ## Tree (`tree.h`)
 
-Intrusive red-black tree wrapping `boost::intrusive::set` / `multiset`. All
-operations are O(log n).
+Intrusive red-black tree wrapping `boost::intrusive::set` / `multiset`. All operations are O(log n).
 
-Objects must embed a `TreeEntry` member (`boost::intrusive::set_member_hook<>`).
-Template parameters: element type, member pointer to hook, comparator,
-`AllowDuplicates` (defaults to `false`).
+Objects must embed a `TreeEntry` member (`boost::intrusive::set_member_hook<>`). Template parameters: element type, member pointer to hook, comparator, `AllowDuplicates` (defaults to `false`).
 
 ```cpp
 struct Task {
@@ -203,21 +167,15 @@ Task * earliest = tree.min();
 tree.remove(earliest);
 ```
 
-`insert()` returns `nullptr` on success; for unique trees it returns the
-existing element if the key is already present. `remove()` returns the
-in-order successor, or `nullptr` if none. Used for sleep deadline ordering in
-the fiber scheduler and for the ordered waiter tree in `FiberSequencer`.
+`insert()` returns `nullptr` on success; for unique trees it returns the existing element if the key is already present. `remove()` returns the in-order successor, or `nullptr` if none. Used for sleep deadline ordering in the fiber scheduler and for the ordered waiter tree in `FiberSequencer`.
 
 ---
 
 ## MemoryPool (`memory-pool.h`)
 
-Lock-free per-CPU memory pool. Objects are allocated in 4-page chunks; freed
-objects go onto a per-CPU free list and are reused before a new chunk is
-allocated.
+Lock-free per-CPU memory pool. Objects are allocated in 4-page chunks; freed objects go onto a per-CPU free list and are reused before a new chunk is allocated.
 
-Objects must embed a `StackEntry` member. Pass a pointer-to-member as the
-second template argument to the typed wrapper.
+Objects must embed a `StackEntry` member. Pass a pointer-to-member as the second template argument to the typed wrapper.
 
 ```cpp
 struct MyNode {
@@ -230,21 +188,15 @@ MyNode * node = pool.allocate(); // nullptr if OOM
 pool.deallocate(node);
 ```
 
-**Per-CPU design** -- the free list is a `ShardedStack`: each CPU holds a local
-linked list updated via rseq critical sections (zero atomic instructions on the
-fast path). When the list fills or empties, a batch is transferred to/from a
-global pool via a single 128-bit CAS. Allocation and deallocation stay local to
-one CPU with no contention on the fast path.
+**Per-CPU design** -- the free list is a `ShardedStack`: each CPU holds a local linked list updated via rseq critical sections (zero atomic instructions on the fast path). When the list fills or empties, a batch is transferred to/from a global pool via a single 128-bit CAS. Allocation and deallocation stay local to one CPU with no contention on the fast path.
 
-Objects are constructed once (via placement new) when first carved from a
-chunk, and destroyed (via `std::destroy_at`) when the pool is torn down.
+Objects are constructed once (via placement new) when first carved from a chunk, and destroyed (via `std::destroy_at`) when the pool is torn down.
 
 ---
 
 ## CPU Topology (`cpu.h`)
 
-Reads CPU topology from sysfs and computes steal cost between two CPUs. Used
-by the work-stealing scheduler to order steal candidates.
+Reads CPU topology from sysfs and computes steal cost between two CPUs. Used by the work-stealing scheduler to order steal candidates.
 
 ```cpp
 std::vector<CpuTopology> topologies(processorCount);
@@ -257,8 +209,7 @@ uint64_t cost = topologyCostCycles(topologies[a], topologies[b]);
 - `/sys/devices/system/cpu/cpuN/topology/core_id`
 - `/sys/devices/system/node/nodeN/cpulist` (NUMA node membership)
 
-Fields are left as `UINT32_MAX` for CPUs whose sysfs entries are absent
-(containers, some VMs).
+Fields are left as `UINT32_MAX` for CPUs whose sysfs entries are absent (containers, some VMs).
 
 **`topologyCostCycles()`** returns estimated steal cost in TSC cycles:
 
@@ -272,11 +223,7 @@ Fields are left as `UINT32_MAX` for CPUs whose sysfs entries are absent
 
 ## Assert (`assert.h`)
 
-`ASSERT(condition[, message])` -- evaluates `condition` and, if false, prints a
-symbolized stack trace (via libbacktrace), the failed condition, file, line, and
-optional formatted message, then calls `abort()`. The condition string and
-location are captured at the call site; the optional message supports
-`std::format`-style arguments.
+`ASSERT(condition[, message])` -- evaluates `condition` and, if false, prints a symbolized stack trace (via libbacktrace), the failed condition, file, line, and optional formatted message, then calls `abort()`. The condition string and location are captured at the call site; the optional message supports `std::format`-style arguments.
 
 ```cpp
 ASSERT(ptr != nullptr);
@@ -296,16 +243,13 @@ LOG_WARN("io_uring submission queue full");
 LOG_ERROR("failed to allocate fiber stack: {}", strerror(errno));
 ```
 
-The level check is inlined at the call site so disabled levels have no
-formatting overhead. Default level is `INFO`. Change it with
-`Logger::setLevel(LogLevel::DEBUG)`.
+The level check is inlined at the call site so disabled levels have no formatting overhead. Default level is `INFO`. Change it with `Logger::setLevel(LogLevel::DEBUG)`.
 
 ---
 
 ## Sanitizer Support (`sanitizers.h`)
 
-Macros that expand to sanitizer runtime calls when the build is instrumented,
-and to no-ops otherwise.
+Macros that expand to sanitizer runtime calls when the build is instrumented, and to no-ops otherwise.
 
 | Macro | Purpose |
 |---|---|
@@ -315,6 +259,4 @@ and to no-ops otherwise.
 | `TSAN_ACQUIRE(addr)` / `TSAN_RELEASE(addr)` | Synthesize happens-before edges |
 | `TSAN_IGNORE_BEGIN()` / `TSAN_IGNORE_END()` | Suppress TSan reports for a region |
 
-These are called by the fiber scheduler around every `fcontext_t` switch so
-that TSan correctly tracks happens-before across fiber boundaries. Without them,
-TSan would report false positives for every access to fiber-local state.
+These are called by the fiber scheduler around every `fcontext_t` switch so that TSan correctly tracks happens-before across fiber boundaries. Without them, TSan would report false positives for every access to fiber-local state.

--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -594,7 +594,6 @@ private:
     }
 
     static void buildStealCandidates() noexcept;
-    static void initCurrentFiber() noexcept;
     static Fiber *
     allocateFiber(FiberMain * fiberMain, FiberParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept;
     static void freeFiber(Fiber * fiber) noexcept;

--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -97,10 +97,27 @@ static inline uint32_t getAvailableProcessorCount() noexcept
 /** Return the index of the CPU the calling thread is currently running on. */
 static inline uint32_t getCurrentProcessor() noexcept
 {
+    // The thread pointer is read through volatile asm rather than __builtin_thread_pointer(). A fiber
+    // may suspend on one OS thread and resume on another (work-stealing, or the SQ-ring-overflow yield
+    // in enqueueIo), which changes the thread pointer mid-function. The C++ abstract machine assumes the
+    // thread pointer is invariant for a thread's lifetime, so with __builtin_thread_pointer() the compiler
+    // is free to hoist the read out of a migration-spanning loop and keep the pre-migration value in a
+    // callee-saved register (which jump_fcontext preserves across the switch), reading the wrong CPU's
+    // rseq area after the migration. The volatile asm forces a fresh read at every use; it cannot be
+    // hoisted or CSE'd across the suspension.
+    char * threadPointer;
+#if defined(__x86_64__)
+    __asm__ volatile("movq %%fs:0, %0" : "=r"(threadPointer));
+#elif defined(__aarch64__)
+    __asm__ volatile("mrs %0, tpidr_el0" : "=r"(threadPointer));
+#else
+#    error Unsupported platform
+#endif
+
     // glibc's sched_getcpu fast path is THREAD_GETMEM_VOLATILE(THREAD_SELF, rseq_area.cpu_id),
     // which is the same rseq read we do here. We skip the function call and the cpu_id >= 0
     // fallback to vDSO/syscall -- safe on Linux 4.18+ / glibc 2.35+ where rseq is always registered.
-    struct rseq * rseq = reinterpret_cast<struct rseq *>(reinterpret_cast<char *>(__builtin_thread_pointer()) + __rseq_offset);
+    struct rseq * rseq = reinterpret_cast<struct rseq *>(threadPointer + __rseq_offset);
     return rseq->cpu_id;
 }
 

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -847,7 +847,7 @@ bool FiberScheduler::ProcessorState::enqueueIo(IoFuture * future, Setup && setup
             if (profiler)
             {
                 future->submitTimestamp = Tsc::getCycles();
-                future->category = threadFiber ? threadFiber->fiberId.category : 0;
+                future->category = getCurrentFiberId().category;
             }
 
             // TSan needs an explicit barrier between submission/completion.
@@ -1177,32 +1177,35 @@ void FiberScheduler::destroy() noexcept
     delete scheduler;
 }
 
-FiberId FiberScheduler::getCurrentFiberId() noexcept
+// noinline is load-bearing, not a hint. These accessors read the threadFiber/proxyFiber
+// thread-locals. A fiber may suspend on one OS thread and resume on another, so a caller
+// that brackets a suspension point must observe the resuming thread's value.
+// If the accessor were inlined, the compiler could materialize the thread pointer once
+// into a callee-saved register and reuse it after the suspension; jump_fcontext preserves
+// callee-saved registers across the switch, so the cached pointer would still address the
+// previous (now idle) thread's thread-local, reading a stale value or null.
+// Keeping the access behind a real call boundary forces a fresh thread-pointer read on
+// every invocation.
+__attribute__((noinline)) FiberId FiberScheduler::getCurrentFiberId() noexcept
 {
     return threadFiber ? threadFiber->fiberId : FiberId{};
 }
 
-Fiber * FiberScheduler::getCurrentFiber() noexcept
+__attribute__((noinline)) Fiber * FiberScheduler::getCurrentFiber() noexcept
 {
     // Fast path: thread is running a regular fiber, or has already lazily
-    // allocated a proxy fiber. Both branches stay inline; only the very first
-    // call from a non-fiber thread reaches initCurrentFiber.
+    // allocated a proxy fiber.
     if (threadFiber)
     {
         return threadFiber;
     }
     if (!proxyFiber) [[unlikely]]
     {
-        initCurrentFiber();
+        // Lazily create a proxy fiber so a non-fiber thread can still participate
+        // in fiber-aware APIs (e.g. FiberMutex::lock, FiberScheduler::run-and-wait).
+        proxyFiber = std::make_unique<Fiber>(true);
     }
     return proxyFiber.get();
-}
-
-__attribute__((noinline)) void FiberScheduler::initCurrentFiber() noexcept
-{
-    // Lazily create a proxy fiber so a non-fiber thread can still participate
-    // in fiber-aware APIs (e.g. FiberMutex::lock, FiberScheduler::run-and-wait).
-    proxyFiber = std::make_unique<Fiber>(true);
 }
 
 bool FiberScheduler::isFiberRunning(Fiber * fiber) noexcept


### PR DESCRIPTION
A fiber can suspend on one scheduler thread and resume on another, but the compiler caches the thread pointer in a callee-saved register that `jump_fcontext` preserves across the switch. After a migration, thread-local reads then address the previous thread's storage and return a stale value or null. This crashed `getCurrentFiber` (null deref of `Fiber::isProxyFiber` at `0x9`) and made `getCurrentProcessor` pick the wrong io_uring ring. It worsens with inlining/unity/LTO; GCC and Clang have no `/GT` equivalent (PR 26461).

Make the accessors independent of the thread pointer being cached:
- `getCurrentProcessor` reads it via volatile asm (`movq %fs:0` / `mrs tpidr_el0`) so it cannot be hoisted across a suspension.
- `getCurrentFiber`/`getCurrentFiberId` are `noinline`, so their reads run in a fresh activation on the current thread.

Add `docs/tls.md` on using thread-local storage from fiber code.