### PR TITLE
Introduce silk::strerror helper

### DIFF
--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -5,6 +5,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #include <sched.h>
 #include <time.h>
@@ -164,6 +165,16 @@ static constexpr uint64_t intHash(uint64_t key) noexcept
     key *= 0xc4ceb9fe1a85ec53ULL;
     key ^= key >> 33;
     return key;
+}
+
+/** Thread-safe strerror_r into a caller-provided buffer; may return nullptr for an unknown code. */
+static inline const char * strerror(int code, char * buf, size_t size) noexcept
+{
+#if defined(_GNU_SOURCE)
+    return ::strerror_r(code, buf, size);
+#else
+    return ::strerror_r(code, buf, size) == 0 ? buf : nullptr;
+#endif
 }
 
 } // namespace silk

--- a/src/perf/net-perf.cpp
+++ b/src/perf/net-perf.cpp
@@ -447,7 +447,7 @@ int Server::acceptFiberMain(AcceptFiberParams * params) noexcept
             delete connection;
             if (!isExpectedShutdown(r))
             {
-                SILK_ERROR("accept failed: %s", strerror(r));
+                SILK_ERROR("accept failed: %s", std::strerror(r));
             }
             break;
         }
@@ -480,7 +480,7 @@ int Server::serverFiberMain(ServerFiberParams * params) noexcept
         {
             if (!isExpectedShutdown(r))
             {
-                SILK_ERROR("read failed: %s", strerror(r));
+                SILK_ERROR("read failed: %s", std::strerror(r));
             }
             break;
         }
@@ -501,7 +501,7 @@ int Server::serverFiberMain(ServerFiberParams * params) noexcept
         {
             if (!isExpectedShutdown(r))
             {
-                SILK_ERROR("write failed: %s", strerror(r));
+                SILK_ERROR("write failed: %s", std::strerror(r));
             }
             break;
         }
@@ -635,7 +635,7 @@ int Client::clientFiberMain(ClientFiberParams * params) noexcept
         {
             if (!isExpectedShutdown(r))
             {
-                SILK_ERROR("write failed: %s", strerror(r));
+                SILK_ERROR("write failed: %s", std::strerror(r));
             }
             break;
         }
@@ -645,7 +645,7 @@ int Client::clientFiberMain(ClientFiberParams * params) noexcept
         {
             if (!isExpectedShutdown(r))
             {
-                SILK_ERROR("read failed: %s", strerror(r));
+                SILK_ERROR("read failed: %s", std::strerror(r));
             }
             break;
         }

--- a/src/profiler/main.cpp
+++ b/src/profiler/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char ** argv)
     int r = symbolizer.readSelfMappings();
     if (r)
     {
-        SILK_ERROR("readSelfMappings: %s", strerror(r));
+        SILK_ERROR("readSelfMappings: %s", std::strerror(r));
         return r;
     }
 
@@ -142,7 +142,7 @@ int main(int argc, char ** argv)
     r = symbolizer.readMappings(targetPid);
     if (r)
     {
-        SILK_ERROR("readMappings: %s", strerror(r));
+        SILK_ERROR("readMappings: %s", std::strerror(r));
         return r;
     }
 
@@ -165,7 +165,7 @@ int main(int argc, char ** argv)
     r = profiler.start();
     if (r)
     {
-        SILK_ERROR("profiler start failed: %s", strerror(r));
+        SILK_ERROR("profiler start failed: %s", std::strerror(r));
         return r;
     }
 

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -148,7 +148,7 @@ int Profiler::start() noexcept
                     // CPU offline
                     continue;
                 }
-                SILK_WARN("perf_event_open cpu %d: %s", cpu, strerror(r));
+                SILK_WARN("perf_event_open cpu %d: %s", cpu, std::strerror(r));
                 continue;
             }
 
@@ -156,7 +156,7 @@ int Profiler::start() noexcept
             if (!link)
             {
                 int r = errno;
-                SILK_WARN("attach perf_event cpu %d: %s", cpu, strerror(r));
+                SILK_WARN("attach perf_event cpu %d: %s", cpu, std::strerror(r));
                 ::close(fd);
                 continue;
             }

--- a/src/profiler/symbolizer.cpp
+++ b/src/profiler/symbolizer.cpp
@@ -20,7 +20,7 @@ static int parseMapsFile(const char * path, Callback callback) noexcept
     if (!f)
     {
         int r = errno;
-        SILK_ERROR("open %s: %s", path, ::strerror(r));
+        SILK_ERROR("open %s: %s", path, std::strerror(r));
         return r;
     }
 
@@ -81,7 +81,7 @@ int Symbolizer::readKallsyms() noexcept
     if (!f)
     {
         int r = errno;
-        SILK_ERROR("open /proc/kallsyms: %s", ::strerror(r));
+        SILK_ERROR("open /proc/kallsyms: %s", std::strerror(r));
         return r;
     }
 
@@ -267,7 +267,7 @@ void Symbolizer::backtraceErrorCb(void * data, const char * msg, int errnum)
 
     if (errnum)
     {
-        SILK_ERROR("libbacktrace: %s (%s)", msg, ::strerror(errnum));
+        SILK_ERROR("libbacktrace: %s (%s)", msg, std::strerror(errnum));
     }
     else
     {

--- a/src/util/error.cpp
+++ b/src/util/error.cpp
@@ -83,6 +83,7 @@ std::string Error::format() const noexcept
     std::string result;
     try
     {
+        char buf[128];
         bool first = true;
         for (const Frame * frame = top(); frame; frame = next(frame))
         {
@@ -105,7 +106,7 @@ std::string Error::format() const noexcept
 
             result += " (errno=";
             result += std::to_string(frame->code);
-            const char * description = strerrordesc_np(frame->code);
+            const char * description = silk::strerror(frame->code, buf, sizeof(buf));
             if (description)
             {
                 result += ": ";


### PR DESCRIPTION
strerrordesc_np requires glibc 2.32 and not portable