### PR TITLE
MSan unpoison read buffer

### DIFF
--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <silk/fibers/future.h>
+#include <silk/util/sanitizers.h>
 #include <silk/util/stack.h>
 #include <silk/util/tree.h>
 
@@ -349,6 +350,11 @@ public:
         // Processor whose io_uring ring holds this SQE; cancelIo must submit
         // the cancel to the same ring to avoid a cross-ring -ENOENT failure.
         uint32_t processorNumber = INVALID_PROCESSOR_NUMBER;
+#if defined(__SANITIZE_MEMORY__)
+        // Used to mark the kernel-written bytes as initialized for MSan.
+        iovec * readIov = nullptr;
+        uint64_t readIovLen = 0;
+#endif
     };
 
     /**

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1424,6 +1424,10 @@ void FiberScheduler::enqueueIo(IoFuture * future, Setup && setup) noexcept
 void FiberScheduler::read(int fd, iovec * iov, uint64_t iov_len, uint64_t offset, uint64_t * bytesRead, IoFuture * future) noexcept
 {
     future->result = bytesRead;
+#if defined(__SANITIZE_MEMORY__)
+    future->readIov = iov;
+    future->readIovLen = iov_len;
+#endif
     enqueueIo(future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_readv(sqe, fd, iov, iov_len, offset); });
 }
 
@@ -1801,6 +1805,16 @@ __attribute__((noinline)) bool FiberScheduler::handleCompletionQueueSlow(Process
                 {
                     *future->result = static_cast<uint64_t>(result);
                 }
+#if defined(__SANITIZE_MEMORY__)
+                // MSan cannot see the kernel filling read buffers via io_uring.
+                uint64_t remaining = static_cast<uint64_t>(result);
+                for (uint64_t i = 0; i < future->readIovLen && remaining > 0; ++i)
+                {
+                    const uint64_t n = std::min<uint64_t>(remaining, future->readIov[i].iov_len);
+                    MSAN_UNPOISON(future->readIov[i].iov_base, n);
+                    remaining -= n;
+                }
+#endif
                 future->set(0);
             }
             else

--- a/src/fibers/tests/fiber-test.cpp
+++ b/src/fibers/tests/fiber-test.cpp
@@ -227,7 +227,8 @@ TEST(Fiber, asyncIoFromThread)
     EXPECT_EQ(r, 0);
     EXPECT_EQ(bytesWritten, sizeof(msg));
 
-    char buf[sizeof(msg)] = {};
+    // Deliberately uninitialized to verify MSan unpoisoning works correctly.
+    char buf[sizeof(msg)];
     iovec riov{buf, sizeof(buf)};
     uint64_t bytesRead = 0;
     FiberScheduler::IoFuture rf;


### PR DESCRIPTION
Currently, when running under MSan, `silk::FiberScheduler::read` does not unpoison the memory that the kernel writes to the user's buffers. So, the memory sanitizer remains unaware of the memory being initialized, making subsequent reads fail.

This issue can only be partially resolved at the user level (by zero-initialising the buffers). For example, if you write a hook that another library calls ([example](https://github.com/ClickHouse/ClickHouse/pull/106078/changes#diff-d1dfae6595d18df835908f36e595b78da7cb962ee21a06c971ddb50d0e7e5fdbR30)).