### PR TITLE
chore: fix `iov_len` type in read/write apis

### DIFF
--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -353,7 +353,7 @@ public:
 #if defined(__SANITIZE_MEMORY__)
         // Used to mark the kernel-written bytes as initialized for MSan.
         iovec * readIov = nullptr;
-        uint64_t readIovLen = 0;
+        uint32_t readIovLen = 0;
 #endif
     };
 
@@ -387,7 +387,7 @@ public:
      * @param bytesRead If not null, receives the number of bytes read on success.
      * @param future    Completion handle; wait() returns 0 on success or a errno on failure.
      */
-    static void read(int fd, iovec * iov, uint64_t iov_len, uint64_t offset, uint64_t * bytesRead, IoFuture * future) noexcept;
+    static void read(int fd, iovec * iov, uint32_t iov_len, uint64_t offset, uint64_t * bytesRead, IoFuture * future) noexcept;
 
     /**
      * Blocking write: submit a write from @p buf and suspend the calling fiber
@@ -419,7 +419,7 @@ public:
      * @param bytesWritten If not null, receives the number of bytes written on success.
      * @param future       Completion handle; wait() returns 0 on success or a errno on failure.
      */
-    static void write(int fd, iovec * iov, uint64_t iov_len, uint64_t offset, uint64_t * bytesWritten, IoFuture * future) noexcept;
+    static void write(int fd, iovec * iov, uint32_t iov_len, uint64_t offset, uint64_t * bytesWritten, IoFuture * future) noexcept;
 
     /**
      * Blocking poll: suspend the calling fiber until one of the requested

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1421,7 +1421,7 @@ void FiberScheduler::enqueueIo(IoFuture * future, Setup && setup) noexcept
     }
 }
 
-void FiberScheduler::read(int fd, iovec * iov, uint64_t iov_len, uint64_t offset, uint64_t * bytesRead, IoFuture * future) noexcept
+void FiberScheduler::read(int fd, iovec * iov, uint32_t iov_len, uint64_t offset, uint64_t * bytesRead, IoFuture * future) noexcept
 {
     future->result = bytesRead;
 #if defined(__SANITIZE_MEMORY__)
@@ -1431,7 +1431,7 @@ void FiberScheduler::read(int fd, iovec * iov, uint64_t iov_len, uint64_t offset
     enqueueIo(future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_readv(sqe, fd, iov, iov_len, offset); });
 }
 
-void FiberScheduler::write(int fd, iovec * iov, uint64_t iov_len, uint64_t offset, uint64_t * bytesWritten, IoFuture * future) noexcept
+void FiberScheduler::write(int fd, iovec * iov, uint32_t iov_len, uint64_t offset, uint64_t * bytesWritten, IoFuture * future) noexcept
 {
     future->result = bytesWritten;
     enqueueIo(future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_writev(sqe, fd, iov, iov_len, offset); });
@@ -1808,7 +1808,7 @@ __attribute__((noinline)) bool FiberScheduler::handleCompletionQueueSlow(Process
 #if defined(__SANITIZE_MEMORY__)
                 // MSan cannot see the kernel filling read buffers via io_uring.
                 uint64_t remaining = static_cast<uint64_t>(result);
-                for (uint64_t i = 0; i < future->readIovLen && remaining > 0; ++i)
+                for (uint32_t i = 0; i < future->readIovLen && remaining > 0; ++i)
                 {
                     const uint64_t n = std::min<uint64_t>(remaining, future->readIov[i].iov_len);
                     MSAN_UNPOISON(future->readIov[i].iov_base, n);


### PR DESCRIPTION
read/write apis accept `iov_len` as `uint64_t` type. But it's un-necessary. 

Even the original iouring api [prep_readv ](https://man7.org/linux/man-pages/man3/io_uring_prep_read.3.html)and [prep_writev ](https://man7.org/linux/man-pages/man3/io_uring_prep_write.3.html)accept this as unsigned (32-bit) value (`unsigned nbytes`).

Currently this does "silent" conversion and it's bad.

It all boils down to the original type of `sqe`'s io_vec length's type. [Which is still u32](https://man7.org/linux/man-pages/man7/io_uring.7.html) according to man page.
``
__u32     len;      /* buffer size or number of iovecs */
``

So this `uint64_t` on the public api is un-necessary and set wrong expectations (io_vec length cannot be more than 2^32).

FYI: I tried to add compile flags like `-Wshorten-64-to-32` and `-Wimplicit-int-conversion` for future regression. But that is causing so many noise from dependencies. Better to take it as follow up PR.
