### PR TITLE
Force-migrate fibers under ThreadSanitizer

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1269,6 +1269,7 @@ void FiberScheduler::enqueueReady(Fiber * fiber) noexcept
                 fiber->processorNumber = getCurrentProcessor();
             }
 
+#ifndef __SANITIZE_THREAD__
             ProcessorState * processor = &scheduler->processorState[fiber->processorNumber];
             if (processor->readyQueue.enqueue(fiber))
             {
@@ -1279,6 +1280,7 @@ void FiberScheduler::enqueueReady(Fiber * fiber) noexcept
 
             // Ready queue full: fall back to worker thread pool.
             Perf::getSimpleCounter(simpleCounters[READY_QUEUE_FULL], processor->number).increment();
+#endif
         }
 
         scheduler->readyQueue.enqueue(fiber);


### PR DESCRIPTION
Using STL synchronisation primitives like `std::mutex` should be thread-affine. If a user calls `std::mutex::lock`, then yield, then resume, then `std::mutex::unlock`, it's a bug because the fiber could migrate to another thread. But in my experience, it's quite hard to hit that bug in CI. To make it much simpler, I suggest we always add the fiber to the global ready queue under TSan.