### PR TITLE
Skip the tree for already-reached waiters in FiberSequencer drain

### DIFF
--- a/src/fibers/benchmarks/sequencer-bench.cpp
+++ b/src/fibers/benchmarks/sequencer-bench.cpp
@@ -6,6 +6,8 @@
 #include <benchmark/benchmark.h>
 
 #include <atomic>
+#include <cstdint>
+#include <vector>
 
 namespace silk
 {
@@ -96,5 +98,43 @@ BENCHMARK_F(FiberSequencerBench, RoundTrip)(benchmark::State & state)
     request.increment();
     responder.wait();
 }
+
+// Fan-in: register N futures at tokens base+1..base+N while the counter sits at base (all push to the request
+// queue and stay pending - no parking), then one advance(base+N) reaches them all in a single drain. Every
+// future's token is <= current at classify time, so this is the case the skip-insert path targets: route
+// straight to the wake list instead of insert-then-immediately-remove from the tree.
+BENCHMARK_DEFINE_F(FiberSequencerBench, FanIn)(benchmark::State & state)
+{
+    struct Params
+    {
+        benchmark::State * state;
+        uint64_t count;
+
+        static int fiberMain(Params * params) noexcept
+        {
+            FiberSequencer sequencer;
+            std::vector<FiberSequencer::Future> futures(params->count);
+            uint64_t base = 0;
+            for (auto _ : *params->state)
+            {
+                for (uint64_t i = 0; i < params->count; ++i)
+                {
+                    futures[i].reset();
+                    sequencer.wait(base + 1 + i, &futures[i]);
+                }
+
+                base += params->count;
+                bool advanced = sequencer.advance(base);
+                SILK_ASSERT(advanced);
+            }
+            return 0;
+        }
+    };
+
+    uint64_t count = static_cast<uint64_t>(state.range(0));
+    int r = FiberScheduler::run(Params::fiberMain, {&state, count});
+    SILK_ASSERT(!r);
+}
+BENCHMARK_REGISTER_F(FiberSequencerBench, FanIn)->Arg(8)->Arg(64)->Arg(512);
 
 } // namespace silk

--- a/src/fibers/sequencer.cpp
+++ b/src/fibers/sequencer.cpp
@@ -106,47 +106,93 @@ void FiberSequencer::drain() noexcept
     {
         uint64_t current = counter.load(std::memory_order_acquire);
 
-        // Drain cancelled futures: they are in the tree (IN_TABLE was set when
-        // cancelWait pushed them here), so remove them directly.
+        // Drain cancelled futures. The wake loop may have already removed (and cleared IN_TABLE on) one whose
+        // token was reached first; Tree::remove is UB on a node already out of the tree, so only remove if we
+        // still hold IN_TABLE. The cancelQueue is the sole completer of a cancelled tree future either way.
         Future * cancelled = cancelQueue.popAll();
         while (cancelled)
         {
             Future * next = RequestQueue::next(cancelled);
-            waiters.remove(cancelled);
-            cancelled->state.fetch_and(~Future::IN_TABLE, std::memory_order_relaxed);
+
+            uint32_t prev = cancelled->state.fetch_and(~Future::IN_TABLE, std::memory_order_relaxed);
+            SILK_ASSERT(prev & Future::CANCELLED);
+            if (prev & Future::IN_TABLE)
+            {
+                waiters.remove(cancelled);
+            }
+
             cancelList.push(cancelled);
             cancelled = next;
         }
 
-        // Classify incoming futures: set IN_TABLE and check whether CANCELLED
-        // raced ahead of us. If so, skip the tree insert and cancel instead.
+        // Classify incoming futures. A future whose token is already reached skips the tree entirely - it
+        // would only be inserted here and immediately popped by the wake loop below. It must NOT set
+        // IN_TABLE: leaving it clear keeps it out of the tree, so a racing cancelWait sees "not in table"
+        // and routes its cancellation through the CANCELLED flag here, rather than enqueuing a tree-removal
+        // for a future that was never inserted (which would also double-set the future).
         Future * future = requestQueue.popAll();
         while (future)
         {
             Future * next = RequestQueue::next(future);
-            uint32_t prev = future->state.fetch_or(Future::IN_TABLE, std::memory_order_acq_rel);
-            if (prev & Future::CANCELLED)
+
+            if (future->token <= current)
             {
-                future->state.fetch_and(~Future::IN_TABLE, std::memory_order_relaxed);
-                cancelList.push(future);
+                uint32_t prev = future->state.load(std::memory_order_acquire);
+                SILK_ASSERT((prev & Future::IN_TABLE) == 0);
+                if (prev & Future::CANCELLED)
+                {
+                    cancelList.push(future);
+                }
+                else
+                {
+                    wakeList.push(future);
+                }
             }
             else
             {
-                waiters.insert(future);
+                // Must wait: claim a tree slot by setting IN_TABLE, unless a cancel raced ahead - then route
+                // to cancel without entering the tree. One CAS, so IN_TABLE is set only on a real insert (no
+                // fetch_or-then-undo); a cancel landing between the load and the CAS just fails it and re-checks.
+                uint32_t prev = future->state.load(std::memory_order_relaxed);
+                for (;;)
+                {
+                    SILK_ASSERT((prev & Future::IN_TABLE) == 0);
+                    if (prev & Future::CANCELLED)
+                    {
+                        cancelList.push(future);
+                        break;
+                    }
+                    if (future->state.compare_exchange_weak(
+                            prev, prev | Future::IN_TABLE, std::memory_order_acq_rel, std::memory_order_relaxed))
+                    {
+                        waiters.insert(future);
+                        break;
+                    }
+                }
             }
+
             future = next;
         }
 
-        // Wake all tree entries whose token has been reached.
+        // Wake reached tree entries. A reached future that was cancelled while tree-resident is already in
+        // the cancelQueue (cancelWait saw IN_TABLE set), so the cancelQueue drain completes it as ECANCELED;
+        // drop it here and route only non-cancelled futures to the wake list, so each lands in exactly one list.
         while (Future * future = waiters.min())
         {
             if (future->token > current)
             {
                 break;
             }
+
+            uint32_t prev = future->state.fetch_and(~Future::IN_TABLE, std::memory_order_relaxed);
+            SILK_ASSERT(prev & Future::IN_TABLE);
+
             waiters.remove(future);
-            future->state.fetch_and(~Future::IN_TABLE, std::memory_order_relaxed);
-            wakeList.push(future);
+
+            if ((prev & Future::CANCELLED) == 0)
+            {
+                wakeList.push(future);
+            }
         }
 
         // Repeat if another thread signalled PENDING while we were draining,


### PR DESCRIPTION
A waiter already reached when the combiner classifies it is routed straight to the wake list instead of being inserted and immediately removed from the tree - 1.65-3.2x on a fan-in of 8-512 waiters.

The must-wait branch sets IN_TABLE in a single CAS instead of fetch_or plus undo, and the wake / cancelQueue paths arbitrate tree removal via the IN_TABLE 1->0 transition, so a cancelled-then-reached waiter completes exactly once.
