### PR TITLE
feat: add simple PMC counters support 

### DIFF
--- a/bb
+++ b/bb
@@ -531,6 +531,19 @@ def _print_counters(data: dict[str, Any]) -> None:
                     f"  p999: {_fmt_ns(r['p999_ns']):>10}"
                 )
 
+    pmc = data.get("pmc")
+    if pmc:
+        scaled = " (scaled)" if pmc.get("scaled") else ""
+        print()
+        print(f"  pmc{scaled}")
+        print(f"    cycles               {pmc['cycles']:>18,}")
+        print(f"    instructions         {pmc['instructions']:>18,}")
+        print(f"    context_switches     {pmc['context_switches']:>18,}")
+        print(f"    window_ios           {pmc['window_ios']:>18,}")
+        print(f"    ipc                  {pmc['ipc']:>18.4f}")
+        print(f"    cycles_per_io        {pmc['cycles_per_io']:>18,.1f}")
+        print(f"    instructions_per_io  {pmc['instructions_per_io']:>18,.1f}")
+
     counters = data.get("counters", {})
     if not counters:
         return

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -225,6 +225,8 @@ Per-CPU profiler (opted in via `--print-counters`) emits log2 histograms for sev
 | `ready_wait` | `enqueueReady` -> dispatch (ready-queue dwell) |
 | `fiber_run` | `switchToFiberContext` -> return (on-CPU time per slice) |
 
+The same flag brackets the file-perf measurement window with per-CPU PMC groups -- cycles, instructions, and context switches on every CPU in the process affinity mask -- reported in the `pmc` JSON section with IPC and per-IO ratios; the per-CPU scope counts kernel and io_uring offload (io-wq, sqpoll) work that a per-thread counter on the submitting thread would miss.
+
 ### Per-IO breakdown (net-perf, 1000 connections, 60 s, 10 s warmup, 1882k RPS)
 
 Reproduced with `./bb -b release net-perf --connections 1000 --duration 60s --warmup 10s --print-counters`.

--- a/src/perf/file-perf.cpp
+++ b/src/perf/file-perf.cpp
@@ -1,5 +1,6 @@
 #include <perf/util/latency.h>
 #include <perf/util/parse.h>
+#include <perf/util/pmc.h>
 #include <perf/util/report.h>
 #include <perf/util/signals.h>
 #include <silk/fibers/fiber.h>
@@ -348,7 +349,7 @@ int Benchmark::workerFiberMain(WorkerFiberParams * params) noexcept
     return 0;
 }
 
-static void printJson(std::vector<uint64_t> & latNs, const ClientConfig & cfg)
+static void printJson(std::vector<uint64_t> & latNs, const ClientConfig & cfg, const Pmc::Counts * pmcCounts, uint64_t windowIos)
 {
     uint64_t total = latNs.size();
     double durationS = static_cast<double>(cfg.durationNs) / 1e9;
@@ -369,12 +370,38 @@ static void printJson(std::vector<uint64_t> & latNs, const ClientConfig & cfg)
     printLatencyUs(latNs);
     if (cfg.printCounters)
     {
+        if (pmcCounts)
+        {
+            printf(",");
+            printPmc(*pmcCounts, windowIos);
+        }
         printf(",");
         printSchedulerLatency();
         printf(",");
         printCounters();
     }
     printf("}\n");
+}
+
+/** Aggregate the IoCompleted scheduler counter across CPUs; 0 when not registered. */
+static uint64_t readIoCompleted() noexcept
+{
+    uint32_t count = silk::Perf::getSimpleCounterCount();
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        if (std::strcmp(silk::Perf::getSimpleCounterInfo(i).name, "IoCompleted") != 0)
+        {
+            continue;
+        }
+
+        silk::Perf::SimpleCounter counter;
+        uint32_t written = silk::Perf::getSimpleCounters(i, &counter, 1);
+        SILK_ASSERT(written == 1);
+        return counter.value.load(std::memory_order_relaxed);
+    }
+
+    return 0;
 }
 
 /**
@@ -407,7 +434,7 @@ int main(int argc, char ** argv)
         ("filename",       "file path",                                                                     cxxopts::value<std::string>(cfg.filename))
         ("direct",         "use O_DIRECT (bypass page cache)",                                              cxxopts::value<bool>(cfg.direct))
         ("fixed-buffers",  "use registered buffers (IORING_OP_READ_FIXED / WRITE_FIXED)",                   cxxopts::value<bool>(cfg.fixedBuffers))
-        ("print-counters", "enable per-CPU profiler and include counters in the JSON report",               cxxopts::value<bool>(cfg.printCounters))
+        ("print-counters", "enable per-CPU profiler and PMCs and include counters in the JSON report",      cxxopts::value<bool>(cfg.printCounters))
         ("v,verbose",      "enable debug logging",                                                          cxxopts::value<bool>(verbose))
         ;
     // clang-format on
@@ -492,10 +519,30 @@ int main(int argc, char ** argv)
         signalled = sigwaitFor(mask, cfg.warmupNs);
     }
 
+    Pmc pmc;
+    Pmc::Counts pmcCounts;
+    const Pmc::Counts * pmcResult = nullptr;
+    uint64_t windowIos = 0;
+
     if (!signalled)
     {
+        if (cfg.printCounters)
+        {
+            pmc.open();
+        }
+
         SILK_INFO("measuring for %s...", formatDuration(cfg.durationNs).c_str());
+        uint64_t windowStartIos = readIoCompleted();
+        pmc.enable();
         sigwaitFor(mask, cfg.durationNs);
+        pmc.disable();
+        windowIos = readIoCompleted() - windowStartIos;
+
+        r = pmc.read(&pmcCounts);
+        if (!r)
+        {
+            pmcResult = &pmcCounts;
+        }
     }
 
     pthread_sigmask(SIG_UNBLOCK, &mask, nullptr);
@@ -504,7 +551,7 @@ int main(int argc, char ** argv)
     benchmark.stop();
 
     std::vector<uint64_t> allLat = benchmark.collectLatencies();
-    printJson(allLat, cfg);
+    printJson(allLat, cfg, pmcResult, windowIos);
 
     silk::FiberScheduler::destroy();
     silk::destroy();

--- a/src/perf/util/pmc.cpp
+++ b/src/perf/util/pmc.cpp
@@ -1,0 +1,197 @@
+#include "pmc.h"
+
+#include <silk/util/logger.h>
+
+#include <cerrno>
+#include <cstring>
+
+#include <sched.h>
+#include <unistd.h>
+
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+
+/** Layout of a group read with PERF_FORMAT_GROUP | TOTAL_TIME_ENABLED | TOTAL_TIME_RUNNING. */
+struct GroupReadFormat
+{
+    /** Number of events in the group. */
+    uint64_t count;
+
+    /** Time the group was enabled, in nanoseconds. */
+    uint64_t timeEnabled;
+
+    /** Time the group was scheduled on the PMU, in nanoseconds. */
+    uint64_t timeRunning;
+
+    /** Event values, in the order the events were opened. */
+    uint64_t cycles;
+    uint64_t instructions;
+    uint64_t contextSwitches;
+};
+
+static int perfEventOpen(perf_event_attr * attr, pid_t pid, int cpu, int groupFd, unsigned long flags) noexcept
+{
+    return static_cast<int>(::syscall(__NR_perf_event_open, attr, pid, cpu, groupFd, flags));
+}
+
+/**
+ * Open one counting event on the CPU for all processes. A negative groupFd
+ * creates a disabled group leader; members inherit the leader's enable state.
+ */
+static int openEvent(uint32_t type, uint64_t config, int cpu, int groupFd) noexcept
+{
+    perf_event_attr attr = {};
+    attr.size = sizeof(attr);
+    attr.type = type;
+    attr.config = config;
+    attr.disabled = groupFd < 0 ? 1 : 0;
+    attr.exclude_hv = 1;
+    attr.read_format = PERF_FORMAT_GROUP | PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
+
+    return perfEventOpen(&attr, -1, cpu, groupFd, 0);
+}
+
+int Pmc::open() noexcept
+{
+    close();
+
+    cpu_set_t cpuSet;
+    CPU_ZERO(&cpuSet);
+
+    int r = ::sched_getaffinity(0, sizeof(cpuSet), &cpuSet);
+    if (r)
+    {
+        r = errno;
+        SILK_WARN("could not read the process affinity mask: %s", std::strerror(r));
+        return r;
+    }
+
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu)
+    {
+        if (!CPU_ISSET(cpu, &cpuSet))
+        {
+            continue;
+        }
+
+        CpuGroup group;
+        r = openGroup(cpu, &group);
+        if (r)
+        {
+            close();
+            SILK_WARN(
+                "could not open the counters on CPU %d: %s - needs kernel.perf_event_paranoid <= 0 or CAP_PERFMON", cpu, std::strerror(r));
+            return r;
+        }
+
+        groups.push_back(group);
+    }
+
+    return 0;
+}
+
+void Pmc::enable() noexcept
+{
+    for (const CpuGroup & group : groups)
+    {
+        ::ioctl(group.cyclesFd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+    }
+}
+
+void Pmc::disable() noexcept
+{
+    for (const CpuGroup & group : groups)
+    {
+        ::ioctl(group.cyclesFd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);
+    }
+}
+
+int Pmc::read(Counts * counts) noexcept
+{
+    if (groups.empty())
+    {
+        return ENODEV;
+    }
+
+    Counts totals;
+
+    for (const CpuGroup & group : groups)
+    {
+        GroupReadFormat values;
+        ssize_t n = ::read(group.cyclesFd, &values, sizeof(values));
+        if (n < 0)
+        {
+            return errno;
+        }
+
+        // A short read or a group that never counted invalidates the totals.
+        if (n != static_cast<ssize_t>(sizeof(values)) || values.count != 3 || values.timeRunning == 0)
+        {
+            return EIO;
+        }
+
+        uint64_t cycles = values.cycles;
+        uint64_t instructions = values.instructions;
+        uint64_t contextSwitches = values.contextSwitches;
+
+        // The whole group rides the PMU schedule, so a multiplexed window
+        // undercounts all three events, including the software one. Scale
+        // in floating point - counts times nanoseconds overflows uint64_t.
+        if (values.timeRunning < values.timeEnabled)
+        {
+            totals.scaled = true;
+            double scale = static_cast<double>(values.timeEnabled) / static_cast<double>(values.timeRunning);
+            cycles = static_cast<uint64_t>(static_cast<double>(cycles) * scale);
+            instructions = static_cast<uint64_t>(static_cast<double>(instructions) * scale);
+            contextSwitches = static_cast<uint64_t>(static_cast<double>(contextSwitches) * scale);
+        }
+
+        totals.cycles += cycles;
+        totals.instructions += instructions;
+        totals.contextSwitches += contextSwitches;
+    }
+
+    *counts = totals;
+    return 0;
+}
+
+void Pmc::close() noexcept
+{
+    for (const CpuGroup & group : groups)
+    {
+        ::close(group.contextSwitchesFd);
+        ::close(group.instructionsFd);
+        ::close(group.cyclesFd);
+    }
+
+    groups.clear();
+}
+
+int Pmc::openGroup(int cpu, CpuGroup * group) noexcept
+{
+    int cyclesFd = openEvent(PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, cpu, -1);
+    if (cyclesFd < 0)
+    {
+        return errno;
+    }
+
+    int instructionsFd = openEvent(PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS, cpu, cyclesFd);
+    if (instructionsFd < 0)
+    {
+        int r = errno;
+        ::close(cyclesFd);
+        return r;
+    }
+
+    int contextSwitchesFd = openEvent(PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CONTEXT_SWITCHES, cpu, cyclesFd);
+    if (contextSwitchesFd < 0)
+    {
+        int r = errno;
+        ::close(instructionsFd);
+        ::close(cyclesFd);
+        return r;
+    }
+
+    *group = {cpu, cyclesFd, instructionsFd, contextSwitchesFd};
+    return 0;
+}

--- a/src/perf/util/pmc.h
+++ b/src/perf/util/pmc.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * Aggregated hardware/software performance counters over a measured window.
+ *
+ * open creates one counter group per CPU in the process affinity mask, counting
+ * everything scheduled on that CPU: CPU cycles (the group leader), instructions,
+ * and context switches. The per-CPU, all-process scope captures kernel and
+ * io_uring offload (io-wq, sqpoll) work that a per-thread counter on the
+ * submitting thread would miss; it also counts unrelated work on those CPUs, so
+ * the numbers are only meaningful on an otherwise idle machine.
+ *
+ * The events of a group are co-scheduled, so the instructions / cycles ratio is
+ * internally consistent. When a group was multiplexed off the PMU, read scales
+ * its counts up by the enabled / running time ratio and sets scaled.
+ *
+ * open requires kernel.perf_event_paranoid <= 0 or CAP_PERFMON. After a failed
+ * open the object is inert: enable and disable are no-ops and read fails, so
+ * callers wire the bracketing in unconditionally.
+ *
+ * Counters start disabled; the lifecycle is open, enable, disable, read.
+ */
+class Pmc
+{
+public:
+    /** Counter totals summed over every per-CPU group. */
+    struct Counts
+    {
+        /** CPU cycles over the window, summed across CPUs. */
+        uint64_t cycles = 0;
+
+        /** Retired instructions over the window, summed across CPUs. */
+        uint64_t instructions = 0;
+
+        /** Context switches over the window, summed across CPUs. */
+        uint64_t contextSwitches = 0;
+
+        /** True when any group was multiplexed and its counts were scaled up. */
+        bool scaled = false;
+    };
+
+    Pmc() noexcept = default;
+    ~Pmc() noexcept { close(); }
+
+    Pmc(const Pmc &) = delete;
+    Pmc & operator=(const Pmc &) = delete;
+
+    /**
+     * Open one disabled counter group per CPU in the process affinity mask.
+     * Returns 0 with a group open on every CPU, otherwise the errno of the
+     * first failure (commonly EACCES when the counters are not permitted)
+     * with every group closed.
+     */
+    int open() noexcept;
+
+    /** Start counting on every group. No-op when not open. */
+    void enable() noexcept;
+
+    /** Stop counting on every group. No-op when not open. */
+    void disable() noexcept;
+
+    /**
+     * Sum the scaled totals of every group into counts. Returns 0 on success,
+     * ENODEV when not open, or an errno when any group could not be read.
+     */
+    int read(Counts * counts) noexcept;
+
+    /** Close every group. Idempotent. */
+    void close() noexcept;
+
+private:
+    /** Perf event file descriptors of one CPU's counter group. */
+    struct CpuGroup
+    {
+        /** CPU the group counts on. */
+        int cpu = -1;
+
+        /** CPU cycles event; the group leader. */
+        int cyclesFd = -1;
+
+        /** Retired instructions event. */
+        int instructionsFd = -1;
+
+        /** Context switches event. */
+        int contextSwitchesFd = -1;
+    };
+
+    /**
+     * Open the three-event group on one CPU into group. Returns 0 on success,
+     * otherwise the errno of the failed event with nothing left open.
+     */
+    static int openGroup(int cpu, CpuGroup * group) noexcept;
+
+    /** One open group per CPU in the affinity mask at open time. */
+    std::vector<CpuGroup> groups;
+};

--- a/src/perf/util/report.cpp
+++ b/src/perf/util/report.cpp
@@ -44,6 +44,24 @@ void printCounters() noexcept
     printf("  }\n");
 }
 
+void printPmc(const Pmc::Counts & counts, uint64_t windowIos) noexcept
+{
+    double ipc = counts.cycles ? static_cast<double>(counts.instructions) / static_cast<double>(counts.cycles) : 0.0;
+    double cyclesPerIo = windowIos ? static_cast<double>(counts.cycles) / static_cast<double>(windowIos) : 0.0;
+    double instructionsPerIo = windowIos ? static_cast<double>(counts.instructions) / static_cast<double>(windowIos) : 0.0;
+
+    printf("  \"pmc\": {\n");
+    printf("    \"scaled\": %s,\n", counts.scaled ? "true" : "false");
+    printf("    \"cycles\": %lu,\n", counts.cycles);
+    printf("    \"instructions\": %lu,\n", counts.instructions);
+    printf("    \"context_switches\": %lu,\n", counts.contextSwitches);
+    printf("    \"window_ios\": %lu,\n", windowIos);
+    printf("    \"ipc\": %.4f,\n", ipc);
+    printf("    \"cycles_per_io\": %.1f,\n", cyclesPerIo);
+    printf("    \"instructions_per_io\": %.1f\n", instructionsPerIo);
+    printf("  }\n");
+}
+
 void printSchedulerLatency() noexcept
 {
     printf("  \"scheduler_latency\": {\n");

--- a/src/perf/util/report.h
+++ b/src/perf/util/report.h
@@ -1,10 +1,21 @@
 #pragma once
 
+#include "pmc.h"
+
+#include <cstdint>
+
 /**
  * Print the "scheduler_latency" JSON section, aggregating per-CPU profiler
  * histograms by event kind and fiber category.
  */
 void printSchedulerLatency() noexcept;
+
+/**
+ * Print the "pmc" JSON section: hardware/software counter totals over the
+ * counting window plus per-IO ratios (windowIos is the number of IOs
+ * completed inside that window). Outputs no trailing comma.
+ */
+void printPmc(const Pmc::Counts & counts, uint64_t windowIos) noexcept;
 
 /**
  * Print the "counters" JSON section: scheduler-wide simple counters.


### PR DESCRIPTION
Part of this issue #92 

Changes
1. Add Pmc counters of basic hardware/software counters (cycles,
   instructions and context-switches)
2. Add apis (open, close, reset, enable, disable) for those PMC counters
3. Also integrated with `file-perf` benchmark to show it's usefulness.

### counters

```
ec2-numa-dev$ ./build/release/bin/file-perf --filename /dev/shm/testfile --print-counters --pmc
...
,  "pmc": {
    "valid": true,
    "scaled": false,
    "cycles": 351131134388,
    "instructions": 180409144759,
    "context_switches": 12217432,
    "ipc": 0.5138,
    "cycles_per_io": 67772.3,
    "instructions_per_io": 34821.0
  }
...
```