### PR TITLE
Add FiberSequencer::stop

### DIFF
--- a/include/silk/fibers/sequencer.h
+++ b/include/silk/fibers/sequencer.h
@@ -15,6 +15,11 @@ namespace silk
  *
  * Waiters register a Future at a specific token; increment advances the
  * counter and wakes all futures whose token has been reached, in token order.
+ *
+ * stop transitions the sequencer into a stopped state: every unreached waiter
+ * is woken with ECANCELED and every subsequent unreached wait completes with
+ * ECANCELED without suspending, while the counter (and increment / advance)
+ * keeps working - a wait at a reached token still returns 0.
  */
 class FiberSequencer
 {
@@ -51,22 +56,27 @@ public:
     /** Return the current counter value for use as a wait token. */
     uint64_t get() const noexcept { return counter.load(std::memory_order_acquire); }
 
-    /** Wait until the counter reaches @p token, blocking the calling fiber. */
-    void wait(uint64_t token) noexcept
+    /**
+     * Wait until the counter reaches @p token, blocking the calling fiber.
+     * Returns 0 on normal wakeup, ECANCELED if the sequencer has been stopped.
+     * Returns 0 immediately if the counter is already >= @p token, even after stop.
+     */
+    int wait(uint64_t token) noexcept
     {
         // Fast path: counter already satisfied.
         if (counter.load(std::memory_order_acquire) >= token)
         {
-            return;
+            return 0;
         }
 
         Future future;
         registerWaiter(token, &future);
-        future.wait();
+        return future.wait();
     }
 
     /**
-     * Register @p future to be set when the counter reaches @p token.
+     * Register @p future to be set when the counter reaches @p token: with 0 on
+     * normal wakeup, with ECANCELED if the sequencer is stopped first.
      * Sets the future immediately if the counter is already >= @p token.
      */
     void wait(uint64_t token, Future * future) noexcept
@@ -116,6 +126,23 @@ public:
         return true;
     }
 
+    /**
+     * Transition into the stopped state and wake every unreached waiter with
+     * ECANCELED. After this, every unreached wait completes with ECANCELED
+     * without suspending; a reached wait still returns 0, and increment /
+     * advance keep working. Idempotent.
+     */
+    void stop() noexcept
+    {
+        // The release store orders the flag before drain's seq_cst fence and queue reads; a racing registerWaiter
+        // either observes the flag in its post-push re-check or its push is observed by this drain - never neither.
+        stopFlag.store(true, std::memory_order_release);
+        drain();
+    }
+
+    /** Returns true if stop has been called. */
+    bool stopped() const noexcept { return stopFlag.load(std::memory_order_acquire); }
+
 private:
     //
     // Constants.
@@ -157,6 +184,7 @@ private:
 
     std::atomic<uint64_t> counter{};
     std::atomic<uint32_t> combinerState{FREE};
+    std::atomic<bool> stopFlag{};
     RequestQueue requestQueue;
     RequestQueue cancelQueue;
     WaiterTree waiters;

--- a/src/fibers/sequencer.cpp
+++ b/src/fibers/sequencer.cpp
@@ -21,10 +21,11 @@ void FiberSequencer::registerWaiter(uint64_t token, Future * future) noexcept
     // below, so a registration racing an advance is never missed by both the re-read and the combiner's scan.
     std::atomic_thread_fence(std::memory_order_seq_cst);
 
-    // Re-check after push: handles the race where increment fired between
-    // the check above and the push. If the counter is now satisfied, become
-    // the combiner and drain the queue (which will set our future immediately).
-    if (counter.load(std::memory_order_acquire) >= token)
+    // Re-check after push: handles the race where increment (or stop) fired
+    // between the check above and the push. If the counter is now satisfied or
+    // the sequencer is stopped, become the combiner and drain the queue (which
+    // will set our future immediately).
+    if (counter.load(std::memory_order_acquire) >= token || stopFlag.load(std::memory_order_acquire))
     {
         drain();
     }
@@ -72,6 +73,7 @@ void FiberSequencer::drain() noexcept
     for (;;)
     {
         uint64_t current = counter.load(std::memory_order_acquire);
+        bool stopping = stopFlag.load(std::memory_order_acquire);
 
         // Drain cancelled futures. The wake loop may have already removed (and cleared IN_TABLE on) one whose
         // token was reached first; Tree::remove is UB on a node already out of the tree, so only remove if we
@@ -114,6 +116,13 @@ void FiberSequencer::drain() noexcept
                 {
                     wakeList.push(future);
                 }
+            }
+            else if (stopping)
+            {
+                // Stopped: an unreached waiter never enters the tree - complete it with ECANCELED. IN_TABLE
+                // stays clear, so a racing cancelWait routes through the CANCELLED flag and enqueues nothing;
+                // this list is the future's sole completer either way.
+                cancelList.push(future);
             }
             else
             {
@@ -159,6 +168,25 @@ void FiberSequencer::drain() noexcept
             if ((prev & Future::CANCELLED) == 0)
             {
                 wakeList.push(future);
+            }
+        }
+
+        // Stopped: flush the remaining (unreached) tree entries with ECANCELED. A tree future cancelled while
+        // tree-resident sits in the cancelQueue (cancelWait saw IN_TABLE), which stays its sole completer -
+        // clearing IN_TABLE here routes the next cancelQueue drain past the tree removal, as in the wake loop.
+        if (stopping)
+        {
+            while (Future * future = waiters.min())
+            {
+                uint32_t prev = future->state.fetch_and(~Future::IN_TABLE, std::memory_order_relaxed);
+                SILK_ASSERT(prev & Future::IN_TABLE);
+
+                waiters.remove(future);
+
+                if ((prev & Future::CANCELLED) == 0)
+                {
+                    cancelList.push(future);
+                }
             }
         }
 

--- a/src/fibers/tests/sequencer-test.cpp
+++ b/src/fibers/tests/sequencer-test.cpp
@@ -43,7 +43,46 @@ TEST(FiberSequencer, waitAlreadySatisfied)
     EXPECT_EQ(err, 0);
 
     // blocking form; must return immediately
-    sequencer.wait(1);
+    EXPECT_EQ(sequencer.wait(1), 0);
+}
+
+TEST(FiberSequencer, stopCancelsUnreachedWaiters)
+{
+    FiberSequencer sequencer;
+    sequencer.increment();
+
+    // Registered before stop: an unreached waiter completes with ECANCELED, a reached one with 0.
+    FiberSequencer::Future unreached;
+    sequencer.wait(2, &unreached);
+    FiberSequencer::Future reached;
+    sequencer.wait(1, &reached);
+
+    EXPECT_FALSE(sequencer.stopped());
+    sequencer.stop();
+    EXPECT_TRUE(sequencer.stopped());
+
+    int err;
+    ASSERT_TRUE(unreached.isSet(&err));
+    EXPECT_EQ(err, ECANCELED);
+    ASSERT_TRUE(reached.isSet(&err));
+    EXPECT_EQ(err, 0);
+
+    // Registered after stop: an unreached wait completes with ECANCELED without suspending, a reached one with 0.
+    FiberSequencer::Future late;
+    sequencer.wait(2, &late);
+    ASSERT_TRUE(late.isSet(&err));
+    EXPECT_EQ(err, ECANCELED);
+    EXPECT_EQ(sequencer.wait(2), ECANCELED);
+    EXPECT_EQ(sequencer.wait(1), 0);
+
+    // The counter keeps working after stop; a wait at the newly reached token returns 0.
+    EXPECT_EQ(sequencer.increment(), 2u);
+    EXPECT_EQ(sequencer.get(), 2u);
+    EXPECT_EQ(sequencer.wait(2), 0);
+
+    // Idempotent.
+    sequencer.stop();
+    EXPECT_TRUE(sequencer.stopped());
 }
 
 TEST(FiberSequencer, waitSuspends)


### PR DESCRIPTION
Mirrors FiberFutex::stop for the ordered-waiter sequencer: stop wakes every unreached waiter with ECANCELED and every subsequent unreached wait completes with ECANCELED without suspending, while the counter (and increment / advance) keeps working - a wait at a reached token still returns 0. The blocking wait overload now returns the wait result.

Callers gating teardown on a sequencer no longer need to advance the counter to a sentinel (corrupting its value for concurrent readers) plus a side flag to tell a real wake from a teardown wake.