### PR TITLE
Build and run perf / bench under the sanitizers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,26 @@ jobs:
             configure_cmd: ./bb -b release configure --build-poco --build-jemalloc
             cmd: ./bb -b release test
             bench_cmd: ./bb -b release bench
-            perf_cmd: ./bb -v -b release perf
+            perf_cmd: ./bb -b release perf file net http
           - name: tsan
             configure_cmd: ./bb -b release -s thread configure --build-poco
             cmd: ./bb -b release -s thread test
             bench_cmd: ./bb -b release -s thread bench
-            perf_cmd: ./bb -v -b release -s thread perf
+            perf_cmd: ./bb -b release -s thread perf file net http
           - name: asan
+            configure_cmd: ./bb -b release -s address configure --build-poco
             cmd: ./bb -b release -s address test
+            bench_cmd: ./bb -b release -s address bench
+            perf_cmd: ./bb -b release -s address perf file net http
           - name: ubsan
+            configure_cmd: ./bb -b release -s undefined configure --build-poco
             cmd: ./bb -b release -s undefined test
+            bench_cmd: ./bb -b release -s undefined bench
+            perf_cmd: ./bb -b release -s undefined perf file net http
           - name: msan
             cmd: ./bb -b release -s memory test
+            bench_cmd: ./bb -b release -s memory bench
+            perf_cmd: ./bb -b release -s memory perf file net
 
     name: test (${{ matrix.arch.name }}, ${{ matrix.build.name }})
 
@@ -76,7 +84,7 @@ jobs:
             contrib/liburing
 
       - name: Init Poco submodule
-        if: matrix.build.name == 'release' || matrix.build.name == 'tsan'
+        if: matrix.build.name != 'coverage' && matrix.build.name != 'msan'
         run: git submodule update --init --depth=1 contrib/poco
 
       - name: Init jemalloc submodule
@@ -128,19 +136,19 @@ jobs:
             ${{ runner.os }}-ccache-${{ matrix.arch.name }}-${{ matrix.build.name }}-
 
       - name: Configure with Poco
-        if: matrix.build.name == 'release' || matrix.build.name == 'tsan'
+        if: matrix.build.name != 'coverage' && matrix.build.name != 'msan'
         run: ${{ matrix.build.configure_cmd }}
 
       - name: Build and test
         run: ${{ matrix.build.cmd }}
 
       - name: bench
-        if: matrix.build.name == 'release' || matrix.build.name == 'tsan'
+        if: matrix.build.name != 'coverage'
         run: ${{ matrix.build.bench_cmd }}
 
       - name: perf
-        if: matrix.build.name == 'release' || matrix.build.name == 'tsan'
-        run: ${{ matrix.build.perf_cmd }} file net http
+        if: matrix.build.name != 'coverage'
+        run: ${{ matrix.build.perf_cmd }}
 
       - name: Upload coverage report
         if: matrix.build.name == 'coverage' && matrix.arch.name == 'amd64'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,14 +169,10 @@ add_compile_options(
 add_subdirectory(src/util)
 add_subdirectory(src/fibers)
 add_subdirectory(src/gdb)
+add_subdirectory(src/perf)
 
-# Perf and profiler targets may pull in system libs with libstdc++ ABI
-# (Poco, AWS SDK) that conflict with the instrumented libc++ used in MSan
-# builds.
-if(NOT SANITIZER STREQUAL "memory")
-    add_subdirectory(src/perf)
-    if(BUILD_LIBBACKTRACE)
-        # symbolizer.cpp depends directly on <backtrace.h>.
-        add_subdirectory(src/profiler)
-    endif()
+# The profiler is not built under MSan.
+# symbolizer.cpp depends directly on <backtrace.h>.
+if(BUILD_LIBBACKTRACE AND NOT SANITIZER STREQUAL "memory")
+    add_subdirectory(src/profiler)
 endif()

--- a/ci/jobs/init_submodules.py
+++ b/ci/jobs/init_submodules.py
@@ -17,6 +17,8 @@ COMMON_SUBMODULES = [
 EXTRA_SUBMODULES_BY_BUILD = {
     "release": ["contrib/poco", "contrib/jemalloc"],
     "tsan": ["contrib/poco"],
+    "asan": ["contrib/poco"],
+    "ubsan": ["contrib/poco"],
     "msan": ["contrib/llvm-project"],
 }
 

--- a/ci/jobs/test_job.py
+++ b/ci/jobs/test_job.py
@@ -14,22 +14,30 @@ _CONFIGS = {
         "configure": "./bb -b release configure --build-poco --build-jemalloc",
         "test": "./bb -b release test",
         "bench": "./bb -b release bench",
-        "perf": "./bb -v -b release perf file net http",
+        "perf": "./bb -b release perf file net http",
     },
     "tsan": {
         "configure": "./bb -b release -s thread configure --build-poco",
         "test": "./bb -b release -s thread test",
         "bench": "./bb -b release -s thread bench",
-        "perf": "./bb -v -b release -s thread perf file net http",
+        "perf": "./bb -b release -s thread perf file net http",
     },
     "asan": {
+        "configure": "./bb -b release -s address configure --build-poco",
         "test": "./bb -b release -s address test",
+        "bench": "./bb -b release -s address bench",
+        "perf": "./bb -b release -s address perf file net http",
     },
     "ubsan": {
+        "configure": "./bb -b release -s undefined configure --build-poco",
         "test": "./bb -b release -s undefined test",
+        "bench": "./bb -b release -s undefined bench",
+        "perf": "./bb -b release -s undefined perf file net http",
     },
     "msan": {
         "test": "./bb -b release -s memory test",
+        "bench": "./bb -b release -s memory bench",
+        "perf": "./bb -b release -s memory perf file net",
     },
 }
 

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -100,16 +100,26 @@ struct CxaEhGlobals
     unsigned int uncaughtExceptions = 0;
 };
 
+// libstdc++ declares __cxxabiv1::__cxa_get_globals in <cxxabi.h>; libc++abi omits it from its public
+// header, so declare the Itanium ABI symbol (matching its internal signature) there.
+#if defined(_LIBCPP_VERSION)
+namespace __cxxabiv1
+{
+struct __cxa_eh_globals;
+extern "C" __cxa_eh_globals * __cxa_get_globals() noexcept;
+}
+#endif
+
 // Read the current thread's exception state. Re-fetched on every switch so a migrated fiber reads
 // the state of whichever thread it now runs on.
 static CxaEhGlobals loadExceptionState() noexcept
 {
-    return *reinterpret_cast<CxaEhGlobals *>(abi::__cxa_get_globals());
+    return *reinterpret_cast<CxaEhGlobals *>(__cxxabiv1::__cxa_get_globals());
 }
 
 static void storeExceptionState(const CxaEhGlobals & state) noexcept
 {
-    *reinterpret_cast<CxaEhGlobals *>(abi::__cxa_get_globals()) = state;
+    *reinterpret_cast<CxaEhGlobals *>(__cxxabiv1::__cxa_get_globals()) = state;
 }
 
 /**

--- a/src/fibers/mutex.cpp
+++ b/src/fibers/mutex.cpp
@@ -2,6 +2,7 @@
 
 #include <silk/fibers/fiber.h>
 #include <silk/util/assert.h>
+#include <silk/util/sanitizers.h>
 #include <silk/util/spinlock.h>
 
 #include <atomic>
@@ -11,6 +12,16 @@ namespace silk
 
 void FiberMutex::lockSlow(State currentState) noexcept
 {
+    // MSan does not follow manual fiber stack switching (google/sanitizers#1232): its per-thread
+    // shadow TLS does not travel with a fiber across suspend/resume, so it can read the by-value
+    // State param as uninitialized though it is initialized. This is the thread-pointer hazard
+    // getCurrentProcessor documents: only arm64 trips it, because reaching __msan_param_tls there
+    // materializes the thread pointer into a callee-saved register jump_fcontext preserves across
+    // the switch, so a migrated fiber reads the old thread's shadow; x86-64's %fs-relative access
+    // stays current. getCurrentProcessor cures its own reads with volatile asm, but param_tls access
+    // is compiler-emitted, so we clear the value's address-based shadow instead.
+    MSAN_UNPOISON(&currentState, sizeof(currentState));
+
     if (currentState.exclusive)
     {
         SILK_ASSERT_DEBUG(
@@ -45,6 +56,9 @@ void FiberMutex::lockSlow(State currentState) noexcept
 
 void FiberMutex::lockSharedSlow(State currentState) noexcept
 {
+    // Same MSan manual-stack-switching workaround as lockSlow (google/sanitizers#1232).
+    MSAN_UNPOISON(&currentState, sizeof(currentState));
+
     static constexpr uint32_t SPIN_COUNT = 16;
 
     // Same spin policy as lockSlow: only when the blocker is an identifiable exclusive owner

--- a/src/perf/CMakeLists.txt
+++ b/src/perf/CMakeLists.txt
@@ -10,8 +10,9 @@ target_link_libraries(net-perf PRIVATE silk-perf cxxopts::cxxopts)
 add_executable(net-perf-epoll net-perf-epoll.cpp)
 target_link_libraries(net-perf-epoll PRIVATE silk-perf cxxopts::cxxopts)
 
-# asio::awaitable requires Boost >= 1.75
-if(Boost_VERSION_STRING VERSION_GREATER_EQUAL "1.75")
+# asio::awaitable requires Boost >= 1.75; Boost.Asio pulls in a libstdc++-ABI system lib, so it is
+# excluded under MSan like http-perf (Poco) and s3-perf (AWS SDK).
+if(Boost_VERSION_STRING VERSION_GREATER_EQUAL "1.75" AND NOT SANITIZER STREQUAL "memory")
     add_executable(net-perf-asio net-perf-asio.cpp)
     target_link_libraries(net-perf-asio PRIVATE silk-perf cxxopts::cxxopts)
 


### PR DESCRIPTION
src/perf is built under every sanitizer instead of being skipped entirely under MSan. The perf targets that pull in a libstdc++-ABI system lib exclude themselves under MSan, where the instrumented libc++ would clash: net-perf-asio (Boost.Asio), and http-perf / s3-perf via BUILD_POCO / BUILD_AWS. file-perf / net-perf / net-perf-epoll depend only on silk-fibers and header-only libraries, so they build everywhere. The profiler stays out of MSan builds.

CI - both the GitHub workflow and the ci/ praktika jobs - now runs test, bench, and perf across release / tsan / asan / ubsan / msan. Poco is built for every build except MSan, so http-perf runs under asan / ubsan too; MSan runs perf as file net; AWS stays off everywhere.