### PR TITLE
Preserve C++ exception state when switching fibers

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -87,6 +87,32 @@ DECLARE_SIMPLE_COUNTERS(FIBER_SIMPLE_COUNTERS);
 
 static Perf::CounterGroup simpleCounters;
 
+// Itanium C++ ABI per-thread exception-propagation state (libstdc++'s __cxxabiv1::__cxa_eh_globals
+// and libc++abi's __cxa_eh_globals share this layout): the stack of exceptions being propagated or
+// handled on the thread, plus the uncaught count. __cxa_throw / __cxa_begin_catch / __cxa_end_catch
+// mutate it and free the exception object through it. It lives in thread-local storage, so every
+// fiber on a scheduler thread shares one copy - silk swaps it per fiber on each context switch so an
+// exception whose unwind spans a switch is not corrupted by another fiber's exception handling.
+struct CxaEhGlobals
+{
+    void * caughtExceptions = nullptr;
+    unsigned int uncaughtExceptions = 0;
+};
+
+extern "C" void * __cxa_get_globals() noexcept;
+
+// Read the current thread's exception state. Re-fetched on every switch so a migrated fiber reads
+// the state of whichever thread it now runs on.
+static CxaEhGlobals loadExceptionState() noexcept
+{
+    return *static_cast<CxaEhGlobals *>(__cxa_get_globals());
+}
+
+static void storeExceptionState(const CxaEhGlobals & state) noexcept
+{
+    *static_cast<CxaEhGlobals *>(__cxa_get_globals()) = state;
+}
+
 /**
  * Fiber lifecycle state.
  */
@@ -216,6 +242,11 @@ public:
 
     // Return value of fiberMain; valid after the fiber reaches STOPPED state.
     int result = 0;
+
+    // This fiber's saved C++ exception-propagation state, swapped with the thread's on each context
+    // switch so an exception crossing the switch is not corrupted by another fiber sharing the thread.
+    // Placed last so it does not shift the offset-pinned fields above.
+    CxaEhGlobals cxaEhGlobals;
 
 #if defined(__SANITIZE_ADDRESS__)
     void * asanFakeStack = nullptr;
@@ -351,8 +382,16 @@ void Fiber::switchToFiberContext() noexcept
     TSAN_FIBER_SWITCH(tsanFiber);
 #endif
 
+    // Save the scheduler's C++ exception state and load this fiber's, so an exception being
+    // propagated on either side is not clobbered by the other (they share the OS thread).
+    CxaEhGlobals schedulerEh = loadExceptionState();
+    storeExceptionState(cxaEhGlobals);
+
     auto transfer = jump_fcontext(fiberContext, this);
     fiberContext = transfer.fctx;
+
+    // The scheduler resumed; restore its exception state.
+    storeExceptionState(schedulerEh);
 
 #if defined(__SANITIZE_ADDRESS__)
     __sanitizer_finish_switch_fiber(schedulerFakeStack, nullptr, nullptr);
@@ -370,6 +409,10 @@ void Fiber::switchToThreadContext(bool final) noexcept
 #if defined(__SANITIZE_THREAD__)
     TSAN_FIBER_SWITCH(tsanSchedulerFiber);
 #endif
+
+    // Save this fiber's C++ exception state; the scheduler restores it (via switchToFiberContext)
+    // before this fiber next resumes.
+    cxaEhGlobals = loadExceptionState();
 
     auto transfer = jump_fcontext(threadContext, nullptr);
     threadContext = transfer.fctx;

--- a/src/fibers/tests/fiber-test.cpp
+++ b/src/fibers/tests/fiber-test.cpp
@@ -428,4 +428,67 @@ TEST(Fiber, yieldStormDoesNotStarveSleep)
     }
 }
 
+// A fiber's C++ exception-propagation state must survive context switches. silk saves and restores
+// it per fiber on every switch; without that, fibers sharing an OS thread corrupt each other's
+// in-flight exception when handling spans a switch - the wrong exception object is freed (observed
+// as a use-after-free or a wrong value) and the original leaks. Many fibers throw and, while
+// handling the exception, yield so their handlers interleave on shared scheduler threads; each must
+// still observe its own exception. Under LeakSanitizer this also catches the orphaned objects.
+TEST(Fiber, exceptionStateIsolatedAcrossSwitch)
+{
+    static constexpr int FIBER_COUNT = 64;
+    static constexpr int ITERATIONS = 200;
+
+    struct Marker
+    {
+        int value;
+    };
+
+    struct Params
+    {
+        int id;
+        std::atomic<int> * mismatches;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            for (int i = 0; i < ITERATIONS; ++i)
+            {
+                int expected = p->id * ITERATIONS + i;
+                try
+                {
+                    FiberScheduler::yield();
+                    throw Marker{expected};
+                }
+                catch (const Marker & marker)
+                {
+                    // Suspend while the exception is live so another fiber's throw / catch can
+                    // interleave on this OS thread; marker must still refer to our own object.
+                    FiberScheduler::yield();
+                    if (marker.value != expected)
+                    {
+                        p->mismatches->fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            }
+            return 0;
+        }
+    };
+
+    std::atomic<int> mismatches{0};
+    FiberFuture futures[FIBER_COUNT];
+
+    for (int i = 0; i < FIBER_COUNT; ++i)
+    {
+        int r = FiberScheduler::run(Params::fiberMain, {i, &mismatches}, &futures[i]);
+        ASSERT_EQ(r, 0);
+    }
+
+    for (int i = 0; i < FIBER_COUNT; ++i)
+    {
+        ASSERT_EQ(futures[i].wait(), 0);
+    }
+
+    ASSERT_EQ(mismatches.load(), 0);
+}
+
 } // namespace silk


### PR DESCRIPTION
A fiber switch swapped the stack and registers but not the thread-local C++ exception state (__cxa_eh_globals). With many fibers per scheduler thread they shared one copy, so an exception whose handling spanned a switch got its bookkeeping corrupted by another fiber's throw / catch - __cxa_end_catch freed the wrong object (use-after-free) and leaked the original. It surfaced as an arm64 LeakSanitizer report under heavy fiber concurrency.

Save and restore each fiber's __cxa_eh_globals on every switch, re-fetched so a migrated fiber uses its current thread. Add a regression test that fails without the fix (heap-use-after-free under AddressSanitizer).