### PR TITLE
Add optional waitCycles to fiber wait primitives

### DIFF
--- a/include/silk/fibers/event.h
+++ b/include/silk/fibers/event.h
@@ -31,14 +31,14 @@ public:
     }
 
     /** Wait until the event is set, blocking the calling fiber. */
-    void wait() noexcept
+    void wait(uint64_t * waitCycles = nullptr) noexcept
     {
         uint64_t current = sequencer.get();
         if (current & 1)
         {
             return;
         }
-        sequencer.wait(current + 1);
+        sequencer.wait(current + 1, waitCycles);
     }
 
     /**

--- a/include/silk/fibers/fair-mutex.h
+++ b/include/silk/fibers/fair-mutex.h
@@ -19,10 +19,10 @@ public:
     using Future = FiberSequencer::Future;
 
     /** Acquire the lock, suspending the calling fiber until it becomes available. */
-    void lock() noexcept
+    void lock(uint64_t * waitCycles = nullptr) noexcept
     {
         uint64_t ticket = nextTicket.fetch_add(1, std::memory_order_relaxed);
-        sequencer.wait(ticket);
+        sequencer.wait(ticket, waitCycles);
     }
 
     /**

--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -316,7 +316,7 @@ public:
      * The callback must handle the race where the wakeup arrives before the fiber
      * is fully suspended.
      */
-    static void suspend(SuspendCallback * callback, void * context) noexcept;
+    static void suspend(SuspendCallback * callback, void * context, uint64_t * waitCycles = nullptr) noexcept;
 
     /**
      * Park a suspended fiber under key until a matching releaseWaiters() call.

--- a/include/silk/fibers/futex.h
+++ b/include/silk/fibers/futex.h
@@ -33,7 +33,7 @@ public:
     }
 
     /** Wait until at least one post fires after this call, or stop() is called. */
-    int wait() noexcept { return wait(get() + 1); }
+    int wait(uint64_t * waitCycles = nullptr) noexcept { return wait(get() + 1, waitCycles); }
 
     /**
      * Wait until the counter reaches @p token, or stop() is called.
@@ -42,7 +42,7 @@ public:
      * the satisfied-token case takes precedence so callers do not lose state changes).
      * @p token is typically obtained as get() + 1 to wait for the next post.
      */
-    [[nodiscard]] int wait(uint64_t token) noexcept;
+    [[nodiscard]] int wait(uint64_t token, uint64_t * waitCycles = nullptr) noexcept;
 
     /** Increment the counter and wake all waiting fibers. No-op once stopped. */
     void post() noexcept;

--- a/include/silk/fibers/future.h
+++ b/include/silk/fibers/future.h
@@ -47,7 +47,7 @@ public:
      * Block until the result is available, then return it.
      * Returns immediately if set() has already been called.
      */
-    int wait() noexcept
+    int wait(uint64_t * waitCycles = nullptr) noexcept
     {
         State currentState;
         currentState.raw = state.load(std::memory_order_acquire);
@@ -55,7 +55,7 @@ public:
         {
             return error;
         }
-        return suspend();
+        return suspend(waitCycles);
     }
 
     /**
@@ -166,7 +166,7 @@ private:
 
     void signal() noexcept;
     Fiber * extractWaitingFiber() noexcept;
-    int suspend() noexcept;
+    int suspend(uint64_t * waitCycles) noexcept;
     static void suspendCallback(Fiber * fiber, FiberFuture * future) noexcept;
     bool attachWaiter(MultipleWaitState * waitState) noexcept;
     bool detachWaiter(MultipleWaitState * waitState) noexcept;

--- a/include/silk/fibers/multi-lock.h
+++ b/include/silk/fibers/multi-lock.h
@@ -64,7 +64,7 @@ public:
     [[nodiscard]] bool try_lock(uint64_t key, ScopedLock * scopedLock) noexcept;
 
     /** Acquire key, suspending the calling fiber until it is free, and populate scopedLock. */
-    void lock(uint64_t key, ScopedLock * scopedLock) noexcept;
+    void lock(uint64_t key, ScopedLock * scopedLock, uint64_t * waitCycles = nullptr) noexcept;
 
 private:
     struct Compare

--- a/include/silk/fibers/mutex.h
+++ b/include/silk/fibers/mutex.h
@@ -42,7 +42,7 @@ public:
     }
 
     /** Acquire the exclusive lock, suspending the calling fiber until it becomes available. */
-    void lock() noexcept
+    void lock(uint64_t * waitCycles = nullptr) noexcept
     {
         State currentState;
         currentState.raw = state.load(std::memory_order_acquire);
@@ -57,7 +57,7 @@ public:
             }
         }
 
-        lockSlow(currentState);
+        lockSlow(currentState, waitCycles);
     }
 
     /** Release the exclusive lock and wake any waiting fibers. */
@@ -106,7 +106,7 @@ public:
      * Acquire a shared lock, suspending the calling fiber until no exclusive holder remains and
      * no exclusive waiter is queued ahead.
      */
-    void lock_shared() noexcept
+    void lock_shared(uint64_t * waitCycles = nullptr) noexcept
     {
         State currentState;
         currentState.raw = state.load(std::memory_order_acquire);
@@ -120,7 +120,7 @@ public:
             }
         }
 
-        lockSharedSlow(currentState);
+        lockSharedSlow(currentState, waitCycles);
     }
 
     /** Release a shared lock and, if last shared holder, wake any waiting fibers. */
@@ -188,8 +188,8 @@ private:
     // Helpers.
     //
 
-    void lockSlow(State currentState) noexcept;
-    void lockSharedSlow(State currentState) noexcept;
+    void lockSlow(State currentState, uint64_t * waitCycles) noexcept;
+    void lockSharedSlow(State currentState, uint64_t * waitCycles) noexcept;
     bool lockHelper(State * currentState) noexcept;
     bool lockSharedHelper(State * currentState) noexcept;
     static void suspendCallback(Fiber * fiber, SuspendCtx * ctx) noexcept;

--- a/include/silk/fibers/sequencer.h
+++ b/include/silk/fibers/sequencer.h
@@ -61,7 +61,7 @@ public:
      * Returns 0 on normal wakeup, ECANCELED if the sequencer has been stopped.
      * Returns 0 immediately if the counter is already >= @p token, even after stop.
      */
-    int wait(uint64_t token) noexcept
+    int wait(uint64_t token, uint64_t * waitCycles = nullptr) noexcept
     {
         // Fast path: counter already satisfied.
         if (counter.load(std::memory_order_acquire) >= token)
@@ -71,7 +71,7 @@ public:
 
         Future future;
         registerWaiter(token, &future);
-        return future.wait();
+        return future.wait(waitCycles);
     }
 
     /**

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1490,8 +1490,10 @@ void FiberScheduler::exitThreadModeSuspendCallback(Fiber * fiber, void * context
     schedule(fiber);
 }
 
-void FiberScheduler::suspend(SuspendCallback * callback, void * context) noexcept
+void FiberScheduler::suspend(SuspendCallback * callback, void * context, uint64_t * waitCycles) noexcept
 {
+    uint64_t suspendStart = waitCycles ? Tsc::getCycles() : 0;
+
     Fiber * fiber = getCurrentFiber();
     fiber->changeState(FiberState::RUNNING, FiberState::SUSPEND_REQUESTED);
 
@@ -1517,6 +1519,11 @@ void FiberScheduler::suspend(SuspendCallback * callback, void * context) noexcep
 
     FiberState fiberState = fiber->state.load(std::memory_order_acquire);
     SILK_ASSERT(fiberState == FiberState::RUNNING);
+
+    if (waitCycles)
+    {
+        *waitCycles += Tsc::getCycles() - suspendStart;
+    }
 }
 
 void FiberScheduler::enqueueWaiter(uint64_t key, Fiber * fiber) noexcept

--- a/src/fibers/futex.cpp
+++ b/src/fibers/futex.cpp
@@ -9,7 +9,7 @@
 namespace silk
 {
 
-int FiberFutex::wait(uint64_t token) noexcept
+int FiberFutex::wait(uint64_t token, uint64_t * waitCycles) noexcept
 {
     // Spin for ~500 ns (16 x ~35 ns PAUSE on Skylake) before suspending.
     static constexpr uint32_t SPIN_COUNT = 16;
@@ -35,7 +35,7 @@ int FiberFutex::wait(uint64_t token) noexcept
     while (!waitHelper(token))
     {
         SuspendCtx ctx{this, token};
-        FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), &ctx);
+        FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), &ctx, waitCycles);
     }
 
     // Re-read state for the cancellation decision. The token-satisfied case

--- a/src/fibers/future.cpp
+++ b/src/fibers/future.cpp
@@ -82,9 +82,9 @@ Fiber * FiberFuture::extractWaitingFiber() noexcept
     }
 }
 
-int FiberFuture::suspend() noexcept
+int FiberFuture::suspend(uint64_t * waitCycles) noexcept
 {
-    FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), this);
+    FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), this, waitCycles);
 
     State currentState;
     currentState.raw = state.load(std::memory_order_acquire);

--- a/src/fibers/multi-lock.cpp
+++ b/src/fibers/multi-lock.cpp
@@ -26,7 +26,7 @@ bool FiberMultiLock::try_lock(uint64_t key, ScopedLock * scopedLock) noexcept
     return true;
 }
 
-void FiberMultiLock::lock(uint64_t key, ScopedLock * scopedLock) noexcept
+void FiberMultiLock::lock(uint64_t key, ScopedLock * scopedLock, uint64_t * waitCycles) noexcept
 {
     WaitEntry * entry = &scopedLock->entry;
     entry->key = key;
@@ -46,7 +46,7 @@ void FiberMultiLock::lock(uint64_t key, ScopedLock * scopedLock) noexcept
         prev->waiters.push_back(entry);
     }
 
-    entry->wait();
+    entry->wait(waitCycles);
 }
 
 void FiberMultiLock::unlock(ScopedLock * scopedLock) noexcept

--- a/src/fibers/mutex.cpp
+++ b/src/fibers/mutex.cpp
@@ -10,7 +10,7 @@
 namespace silk
 {
 
-void FiberMutex::lockSlow(State currentState) noexcept
+void FiberMutex::lockSlow(State currentState, uint64_t * waitCycles) noexcept
 {
     // MSan does not follow manual fiber stack switching (google/sanitizers#1232): its per-thread
     // shadow TLS does not travel with a fiber across suspend/resume, so it can read the by-value
@@ -49,12 +49,12 @@ void FiberMutex::lockSlow(State currentState) noexcept
     while (!lockHelper(&currentState))
     {
         SuspendCtx ctx{this, true};
-        FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), &ctx);
+        FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), &ctx, waitCycles);
         currentState.raw = state.load(std::memory_order_relaxed);
     }
 }
 
-void FiberMutex::lockSharedSlow(State currentState) noexcept
+void FiberMutex::lockSharedSlow(State currentState, uint64_t * waitCycles) noexcept
 {
     // Same MSan manual-stack-switching workaround as lockSlow (google/sanitizers#1232).
     MSAN_UNPOISON(&currentState, sizeof(currentState));
@@ -84,7 +84,7 @@ void FiberMutex::lockSharedSlow(State currentState) noexcept
     while (!lockSharedHelper(&currentState))
     {
         SuspendCtx ctx{this, false};
-        FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), &ctx);
+        FiberScheduler::suspend(reinterpret_cast<FiberScheduler::SuspendCallback *>(suspendCallback), &ctx, waitCycles);
         currentState.raw = state.load(std::memory_order_relaxed);
     }
 }


### PR DESCRIPTION
FiberScheduler::suspend takes an optional uint64_t * waitCycles and, when non-null, adds the TSC cycles the calling fiber was actually suspended. The fast paths never read the TSC, and the pre-suspend spin is excluded because the measurement brackets only the context switch inside suspend.

FiberMutex::lock/lock_shared, FiberFuture::wait, FiberSequencer::wait, and FiberFutex::wait thread the pointer through to suspend, so callers can measure real park time without timing uncontended acquisitions or spin waits. All parameters default to nullptr, so existing callers are unchanged.