### PR TITLE
Fail loudly on fiber leaks in FiberScheduler::destroy

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1041,7 +1041,6 @@ struct FiberScheduler::SchedulerState
     uint16_t schedulerThreadCount = 0;
     uint16_t workerThreadCount = 0;
 
-    std::unique_ptr<ProcessorState[]> processorState;
     std::unique_ptr<std::thread[]> schedulerThreads;
     std::unique_ptr<std::thread[]> workerThreads;
 
@@ -1052,6 +1051,11 @@ struct FiberScheduler::SchedulerState
 
     std::unique_ptr<WaitStack[]> waiterTable;
     uint64_t waiterTableMask{};
+
+    // Declared last so it is destroyed first: each ProcessorState's suspended
+    // list links nodes embedded in pool-owned fibers, so the lists must be
+    // destroyed before fiberPool frees the fiber memory.
+    std::unique_ptr<ProcessorState[]> processorState;
 };
 
 FiberScheduler::SchedulerState::SchedulerState() noexcept
@@ -1261,6 +1265,24 @@ void FiberScheduler::destroy() noexcept
     for (uint16_t i = 0; i < scheduler->workerThreadCount; ++i)
     {
         scheduler->workerThreads[i].join();
+    }
+
+    // A fiber still linked here suspended (or stayed scheduled) and never ran
+    // to completion: the caller leaked it, violating the contract that no
+    // fibers exist at destroy time. Fail here, where the leak is attributable,
+    // instead of corrupting teardown.
+    SILK_ASSERT(scheduler->readyQueue.empty(), "fiber leaked: still in the global ready queue");
+    for (uint16_t cpu = 0; cpu < scheduler->processorCount; ++cpu)
+    {
+        ProcessorState * processor = &scheduler->processorState[cpu];
+        SILK_ASSERT(processor->suspendedList.empty(), "fiber leaked: still suspended on cpu %u", cpu);
+
+        // readyQueue.empty() touches the slot array, which exists only for
+        // processors that were actually initialized.
+        if (processor->number != kInvalidProcessorNumber)
+        {
+            SILK_ASSERT(processor->readyQueue.empty(), "fiber leaked: still ready on cpu %u", cpu);
+        }
     }
 
     delete scheduler;

--- a/src/gdb/fiber.py
+++ b/src/gdb/fiber.py
@@ -965,9 +965,21 @@ class FiberSaveContext(gdb.Command):
         if _saved_ctx is not None:
             print("fiber-savecontext: warning: overwriting previous saved context")
 
-        arch = _arch()
-        thread_num = gdb.selected_thread().num
-        regs = {r: _get_reg(r) for r in _ALL_REGS[arch]}
+        # Register reads are selected-frame-relative; with an older frame
+        # selected (e.g. by crash-dumper.py's silk-frame search) they return
+        # that frame's unwound PC/SP, and restoring those would resume the
+        # thread mid-stack, abandoning the frames below. Snapshot the newest
+        # frame's registers - the thread's true state - then put the caller's
+        # frame selection back.
+        selected_frame = gdb.selected_frame()
+        gdb.newest_frame().select()
+        try:
+            arch = _arch()
+            thread_num = gdb.selected_thread().num
+            regs = {r: _get_reg(r) for r in _ALL_REGS[arch]}
+        finally:
+            selected_frame.select()
+
         _saved_ctx = {"arch": arch, "thread_num": thread_num, "regs": regs}
 
         pc_reg = _PC_REG[arch]


### PR DESCRIPTION
Fail loudly on fiber leaks in FiberScheduler::destroy

A fiber left suspended at destroy() time made teardown walk freed
memory: SchedulerState destroyed fiberPool before processorState, so
each ProcessorState's suspendedList destructor iterated intrusive
nodes living in already-freed pool chunks.