### PR TITLE
Build perf and profiler targets under MSan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,7 @@ add_subdirectory(src/fibers)
 add_subdirectory(src/gdb)
 add_subdirectory(src/perf)
 
-# The profiler is not built under MSan.
 # symbolizer.cpp depends directly on <backtrace.h>.
-if(BUILD_LIBBACKTRACE AND NOT SANITIZER STREQUAL "memory")
+if(BUILD_LIBBACKTRACE)
     add_subdirectory(src/profiler)
 endif()

--- a/src/perf/CMakeLists.txt
+++ b/src/perf/CMakeLists.txt
@@ -10,9 +10,8 @@ target_link_libraries(net-perf PRIVATE silk-perf cxxopts::cxxopts)
 add_executable(net-perf-epoll net-perf-epoll.cpp)
 target_link_libraries(net-perf-epoll PRIVATE silk-perf cxxopts::cxxopts)
 
-# asio::awaitable requires Boost >= 1.75; Boost.Asio pulls in a libstdc++-ABI system lib, so it is
-# excluded under MSan like http-perf (Poco) and s3-perf (AWS SDK).
-if(Boost_VERSION_STRING VERSION_GREATER_EQUAL "1.75" AND NOT SANITIZER STREQUAL "memory")
+# asio::awaitable requires Boost >= 1.75
+if(Boost_VERSION_STRING VERSION_GREATER_EQUAL "1.75")
     add_executable(net-perf-asio net-perf-asio.cpp)
     target_link_libraries(net-perf-asio PRIVATE silk-perf cxxopts::cxxopts)
 
@@ -34,6 +33,10 @@ if(BUILD_POCO)
 endif()
 
 if(BUILD_AWS)
+    if(NOT BUILD_POCO)
+        message(FATAL_ERROR "s3-perf requires BUILD_POCO=ON")
+    endif()
+
     add_executable(s3-perf s3-perf.cpp)
     target_link_libraries(s3-perf PRIVATE silk-perf-http cxxopts::cxxopts aws-cpp-sdk-s3 aws-cpp-sdk-core)
 


### PR DESCRIPTION
The MSan exclusions guarded nothing: net-perf-asio links no Boost library (Boost.System is header-only), and the profiler chain (libbacktrace, libbpf, bpftool) is vendored, so all of it inherits the instrumentation and the from-source libc++. Poco and the AWS SDK remain behind their opt-in options. Fail at configure time when BUILD_AWS is set without BUILD_POCO - s3-perf links silk-perf-http, which only exists with Poco.