### PR TITLE
Restrict the scheduler to an active CPU set

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -2,15 +2,23 @@
 
 ## Overview
 
-This is a cooperative fiber scheduler with per-CPU threads and io_uring integration. Each CPU runs one scheduler thread that owns its own io_uring ring, ready queue, sleep tree, and wakeup signaling infrastructure.
+This is a cooperative fiber scheduler with per-CPU threads and io_uring integration. Each CPU in the active set runs one scheduler thread that owns its own io_uring ring, ready queue, sleep tree, and wakeup signaling infrastructure.
 
 Source lives under `src/fibers/`. Data structures and utilities are in `src/util/` (see `docs/util.md`). Synchronization primitives are in `docs/sync.md`.
 
 ---
 
+## Active CPU Set
+
+The active set is the affinity mask of the thread calling `initialize` (`sched_getaffinity`) intersected with `Options::cpuMask`, a `cpu_set_t` of allowed CPUs with every CPU set by default, admitting the whole affinity mask. A scheduler thread is started and pinned only on each active CPU, and the thread-mode worker pool is pinned to the set of active CPUs, so silk schedules no fiber on a CPU outside the active set (a proxy fiber is the caller's own thread and runs wherever that thread runs). This lets a user reserve CPUs for other activity - busy-loop pollers, for example - by clearing their bits in `cpuMask`.
+
+`processorState` is sized to every configured CPU and indexed by raw CPU id, so a CPU left out of the active set keeps `number == kInvalidProcessorNumber` and owns no ring or ready queue. Work injected from a thread running on such a CPU (a reserved-core poller calling `run`, `schedule`, `sleep`, or IO) is redirected to a home active CPU: each configured CPU maps to itself when active, or to an active CPU chosen round-robin when not, so injection lands on a real ring and spreads across the active set instead of piling onto one. The redirect keys off the current CPU read fresh on every call, so a fiber that migrates mid-flight is always routed by the CPU it currently runs on.
+
+---
+
 ## Scheduler Loop
 
-`FiberScheduler` runs one scheduler thread per CPU, each owning:
+`FiberScheduler` runs one scheduler thread per active CPU, each owning:
 
 - An io_uring ring (256 entries by default, `Options::ioUringQueueSize`) for async IO
 - An eventfd for cross-CPU wakeup signaling
@@ -34,7 +42,7 @@ Fiber lifecycle: `SUSPENDED -> READY -> RUNNING -> STOPPED`. `SUSPEND_REQUESTED`
 
 `FiberState` is defined in `fiber.cpp` (not `fiber.h`) as an implementation detail. `SleepFuture`, `SleepStack`, and `SleepTree` are declared/aliased in the private section of `FiberScheduler` (in `fiber.h`) so they are accessible from `fiber.cpp`.
 
-`processorNumber` tracks which CPU's ready queue the fiber targets. It is set by `schedule()` on first dispatch (assigned to the current CPU when still `UINT32_MAX`) and updated by `runStealLoop` when a fiber is stolen (reassigned to the stealing CPU). When a fiber runs on a worker thread via thread mode, `processorNumber` is not updated - the fiber returns to its last assigned CPU's queue on `exitThreadMode()`.
+`processorNumber` tracks which CPU's ready queue the fiber targets. It is set by `schedule()` on first dispatch (assigned to the scheduling caller's home processor when still `kInvalidProcessorNumber`) and updated by `runStealLoop` when a fiber is stolen (reassigned to the stealing CPU). When a fiber runs on a worker thread via thread mode, `processorNumber` is not updated - the fiber returns to its last assigned CPU's queue on `exitThreadMode()`.
 
 ---
 
@@ -73,7 +81,7 @@ A fiber that needs to make blocking syscalls or perform heavy CPU work can escap
 There are two ready queues:
 
 - **Per-CPU ready queue** (`ProcessorState::readyQueue`) - bounded MPMC queue drained by the CPU's scheduler thread. Normal cooperative fibers live here.
-- **Shared ready queue** (`SchedulerState::readyQueue`) - unbounded MPMC queue drained by the worker thread pool (one worker thread per CPU, sized `workerThreadCount == schedulerThreadCount`, running `runThreadWorker`). Thread-mode fibers live here, and normal fibers overflow here when a CPU ready queue is full.
+- **Shared ready queue** (`SchedulerState::readyQueue`) - unbounded MPMC queue drained by the worker thread pool (one worker thread per active CPU, sized `workerThreadCount == schedulerThreadCount`, pinned to the active set, running `runThreadWorker`). Thread-mode fibers live here, and normal fibers overflow here when a CPU ready queue is full.
 
 `enterThreadMode()` sets `fiber->inThreadMode` and calls `schedule()`, which routes the fiber to the shared ready queue. A worker thread dequeues it and runs it via `runFiber(nullptr, fiber)`, where it may block freely. When the fiber suspends inside thread mode (e.g. waiting on a future), `schedule()` re-enqueues it to the shared ready queue when it is woken - any free worker picks it up.
 
@@ -121,10 +129,10 @@ Each of `read`, `write`, and `poll` has two overloads: a blocking form that subm
 
 `readFixed` / `writeFixed` are async-only counterparts to `read`/`write` that submit `IORING_OP_READ_FIXED` / `IORING_OP_WRITE_FIXED` against a buffer that was pre-registered with the kernel via `registerBuffers`. Instead of passing an iovec the kernel must pin per IO, the caller passes a `(buf, len)` plus the `bufIndex` of a previously registered buffer; the kernel reuses the pre-pinned page mapping and skips the per-IO page-pin and iovec import. `buf` must lie inside the registered buffer at `bufIndex`.
 
-`registerBuffers(iovecs, count)` registers one buffer set on **every** per-CPU io_uring ring, so a fiber that is work-stolen to another CPU can still submit fixed IO referencing the same index. Buffers are addressable as `bufIndex` `0..count-1`. Constraints:
+`registerBuffers(iovecs, count)` registers one buffer set on **every active** CPU's io_uring ring, so a fiber that is work-stolen to another CPU can still submit fixed IO referencing the same index. Buffers are addressable as `bufIndex` `0..count-1`. Constraints:
 
 - Call once, after `initialize()` and before issuing any fixed-buffer IO. io_uring allows a single buffer set per ring with no way to undo or change it, so a second call fails (`-EBUSY`) and trips an assert.
-- Each ring pins its own copy, so total locked memory is `(number of CPUs) * (size of all buffers)`. With many CPUs or large buffers this can exceed `RLIMIT_MEMLOCK`; registration then fails and trips an assert.
+- Each ring pins its own copy, so total locked memory is `(number of active CPUs) * (size of all buffers)`. With many CPUs or large buffers this can exceed `RLIMIT_MEMLOCK`; registration then fails and trips an assert.
 
 The underlying liburing helpers are `io_uring_register_buffers`, `io_uring_prep_read_fixed`, and `io_uring_prep_write_fixed`. `file-perf --fixed-buffers` exercises this path (see `docs/perf.md`).
 

--- a/docs/util.md
+++ b/docs/util.md
@@ -13,7 +13,7 @@ Cross-platform constants and thin OS wrappers.
 | `UNUSED(x)` | Suppresses unused-variable warnings via `(void)(x)` |
 | `PAGE_SIZE` | System page size (4096 bytes) |
 | `CACHELINE_SIZE` | Cache line size (64 bytes) |
-| `getProcessorCount()` | Number of online CPUs (`sysconf(_SC_NPROCESSORS_ONLN)`) |
+| `getProcessorCount()` | Number of configured CPUs (`sysconf(_SC_NPROCESSORS_CONF)`), covering offline-but-present CPUs so a raw CPU id indexes per-CPU state in bounds |
 | `getCurrentProcessor()` | Index of the CPU the calling thread is on (`sched_getcpu`) |
 | `schedYield()` | Yield the calling thread's timeslice (`sched_yield`) |
 | `cpuPause()` | CPU pause hint for spin loops |

--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <silk/fibers/future.h>
+#include <silk/util/platform.h>
 #include <silk/util/sanitizers.h>
 #include <silk/util/stack.h>
 #include <silk/util/tree.h>
@@ -100,6 +101,9 @@ public:
      */
     struct Options
     {
+        /** Return the cpu_set_t with every CPU set - the cpuMask default. */
+        static cpu_set_t defaultCpuMask() noexcept;
+
         // Per-fiber stack size in bytes. Must be a multiple of the system page size.
         // The pool also reserves two guard pages adjacent to each stack.
         uint32_t fiberStackSize = 64 * 1024;
@@ -145,6 +149,13 @@ public:
         // isolation (e.g. head-of-line blocking benchmarks).
         // Production should leave this off.
         bool disableWorkStealing = false;
+
+        // Restrict scheduler and worker threads to the CPUs whose bit is set
+        // here, intersected with the affinity mask of the thread calling
+        // initialize. All CPUs are set by default, admitting the whole affinity
+        // mask; clear the bits of CPUs to reserve (CPU_CLR). The intersection
+        // must be non-empty.
+        cpu_set_t cpuMask = defaultCpuMask();
 
         // Optional per-fiber context-switch hooks. fiberResume fires on the
         // thread about to run the fiber, immediately before control enters it
@@ -456,8 +467,8 @@ public:
     writeFixed(int fd, const void * buf, uint32_t len, uint64_t offset, int bufIndex, uint64_t * bytesWritten, IoFuture * future) noexcept;
 
     /**
-     * Register a fixed buffer set on every per-CPU io_uring ring, so a fiber that
-     * is work-stolen to another CPU can still submit READ_FIXED/WRITE_FIXED
+     * Register a fixed buffer set on every active CPU's io_uring ring, so a fiber
+     * that is work-stolen to another CPU can still submit READ_FIXED/WRITE_FIXED
      * referencing the same index. Call once after initialize(), before issuing any
      * fixed-buffer IO. @p count buffers are addressable as bufIndex 0..count-1.
      *
@@ -466,9 +477,9 @@ public:
      * trips an assert.
      *
      * Each ring pins its own copy of the buffers in memory, so the total locked
-     * memory is (number of CPUs) * (size of all buffers). With many CPUs or large
-     * buffers this can go over the RLIMIT_MEMLOCK limit; if it does, registration
-     * fails and trips an assert.
+     * memory is (number of active CPUs) * (size of all buffers). With many CPUs or
+     * large buffers this can go over the RLIMIT_MEMLOCK limit; if it does,
+     * registration fails and trips an assert.
      *
      * Not NUMA-aware. Registration only pins the existing pages (it never copies
      * or migrates them), so the physical pages stay on whatever node first-touched
@@ -657,6 +668,7 @@ private:
         std::destroy_at(static_cast<T *>(p));
     }
 
+    static ProcessorState * currentProcessor() noexcept;
     static void buildStealCandidates() noexcept;
     static Fiber *
     allocateFiber(FiberMain * fiberMain, FiberParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept;

--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -53,8 +53,9 @@ static constexpr uint64_t kCacheLineSize = CACHE_LINESIZE;
 static constexpr uint64_t kCacheLineSize = 64;
 #endif
 
-/** Hard cap on CPU index (largest known socket: 384 cores). */
+/** Sentinel for an absent processor and exclusive upper bound on valid CPU ids (largest known socket: 384 cores). */
 static constexpr uint16_t kInvalidProcessorNumber = (1 << 10);
+static_assert(kInvalidProcessorNumber <= CPU_SETSIZE, "raw CPU ids up to kInvalidProcessorNumber must be addressable in a cpu_set_t");
 
 /** Round @p value up to the nearest multiple of @p align (must be a power of two). */
 template <typename T>
@@ -106,10 +107,10 @@ static T * containerOf(M * member, M T::* memberPtr) noexcept
     return reinterpret_cast<T *>(reinterpret_cast<uint8_t *>(member) - memberOffset(memberPtr));
 }
 
-/** Return the total number of online processors. */
+/** Return the number of configured processors - covers offline-but-present CPUs, so a raw CPU id indexes per-CPU state in bounds. */
 static inline uint16_t getProcessorCount() noexcept
 {
-    return static_cast<uint16_t>(sysconf(_SC_NPROCESSORS_ONLN));
+    return static_cast<uint16_t>(sysconf(_SC_NPROCESSORS_CONF));
 }
 
 /** Return the number of processors available to the calling process (respects taskset/cgroup affinity). */

--- a/src/fibers/benchmarks/CMakeLists.txt
+++ b/src/fibers/benchmarks/CMakeLists.txt
@@ -1,4 +1,11 @@
 file(GLOB_RECURSE BENCH_SOURCES CONFIGURE_DEPENDS *.cpp)
 
+# cpuset-bench is its own executable: it needs a main that restricts the scheduler
+# to a CPU subset before running, so it cannot share fibers-bench's global init.
+list(REMOVE_ITEM BENCH_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cpuset-bench.cpp)
+
 add_executable(fibers-bench ${BENCH_SOURCES})
 target_link_libraries(fibers-bench PRIVATE silk-fibers Fcontext::Fcontext benchmark::benchmark)
+
+add_executable(fibers-cpuset-bench cpuset-bench.cpp)
+target_link_libraries(fibers-cpuset-bench PRIVATE silk-fibers Fcontext::Fcontext benchmark::benchmark)

--- a/src/fibers/benchmarks/cpuset-bench.cpp
+++ b/src/fibers/benchmarks/cpuset-bench.cpp
@@ -1,0 +1,240 @@
+#include <silk/fibers/fiber.h>
+#include <silk/fibers/future.h>
+#include <silk/util/assert.h>
+#include <silk/util/crash-dumper.h>
+#include <silk/util/init.h>
+#include <silk/util/perf.h>
+#include <silk/util/platform.h>
+
+#include <benchmark/benchmark.h>
+
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include <sched.h>
+
+#include <fibers/cpu.h>
+
+namespace silk
+{
+
+/**
+ * The scheduler is restricted to a strict subset of the available CPUs, leaving
+ * excludedCpu online but off the active set. The benchmarks inject work from a
+ * thread pinned to an active core and from one pinned to the reserved core: the
+ * pair compares the two operating points a cpuMask user chooses between. The arms
+ * differ in park and wake behavior and in core sharing, not only in the injection
+ * redirect, so the delta prices the operating point, not the redirect.
+ */
+class CpuSetBench : public benchmark::Fixture
+{
+protected:
+    /** Move the calling thread onto @p cpu. */
+    static void pinToCpu(int cpu) noexcept
+    {
+        int r = pinThreadToCpu(static_cast<uint16_t>(cpu));
+        SILK_ASSERT(!r, "could not pin the injecting thread: r=%d", r);
+    }
+
+    /** Accumulated value of the named simple counter across every CPU slot, or 0 when no counter carries that name. */
+    static uint64_t readCounter(const char * name) noexcept;
+
+    /**
+     * Ring of numberOfFibers in-flight no-op fibers injected from the calling
+     * thread: each iteration joins the oldest and injects a replacement, so the
+     * cost measured is one injection plus one join. Mirrors
+     * WorkStealingThreadProducer, with the caller's CPU as the only variable.
+     *
+     * Reports, per iteration, the scheduler parks and wakes the loop caused.
+     * Parks counts threads that actually parked, each paying the park syscall
+     * itself; wakes counts signals sent to a thread that advertised itself as
+     * sleeping, each costing the signaling side a wakeup syscall. A thread
+     * backing out of the park path makes wakes exceed parks. Counters are
+     * process-wide, so idle-thread background activity rides along.
+     */
+    static void injectFromCurrentCpu(benchmark::State & state, uint64_t numberOfFibers) noexcept;
+
+public:
+    /** CPUs in the scheduler's active set. Populated by main. */
+    static std::vector<int> activeCpus;
+
+    /** The reserved CPU. Populated by main; -1 when there are too few CPUs to reserve one, and every benchmark skips. */
+    static int excludedCpu;
+};
+
+std::vector<int> CpuSetBench::activeCpus;
+int CpuSetBench::excludedCpu = -1;
+
+uint64_t CpuSetBench::readCounter(const char * name) noexcept
+{
+    uint32_t count = Perf::getSimpleCounterCount();
+    std::vector<Perf::SimpleCounter> out(count);
+    count = Perf::getSimpleCounters(0, out.data(), count);
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        int r = std::strcmp(Perf::getSimpleCounterInfo(i).name, name);
+        if (!r)
+        {
+            return out[i].value.load(std::memory_order_relaxed);
+        }
+    }
+
+    return 0;
+}
+
+void CpuSetBench::injectFromCurrentCpu(benchmark::State & state, uint64_t numberOfFibers) noexcept
+{
+    struct Params
+    {
+        static int fiberMain(Params *) noexcept { return 0; }
+    };
+
+    auto futures = std::make_unique<FiberFuture[]>(numberOfFibers);
+    for (uint64_t i = 0; i < numberOfFibers; ++i)
+    {
+        int r = FiberScheduler::run(Params::fiberMain, {}, &futures[i]);
+        SILK_ASSERT(!r);
+    }
+
+    uint64_t parkedBefore = readCounter("SchedulerThreadParked");
+    uint64_t wakedBefore = readCounter("SchedulerThreadWaked");
+
+    uint64_t pos = 0;
+    for (auto _ : state)
+    {
+        futures[pos % numberOfFibers].wait();
+        futures[pos % numberOfFibers].reset();
+        int r = FiberScheduler::run(Params::fiberMain, {}, &futures[pos % numberOfFibers]);
+        SILK_ASSERT(!r);
+        ++pos;
+    }
+
+    uint64_t parked = readCounter("SchedulerThreadParked") - parkedBefore;
+    uint64_t waked = readCounter("SchedulerThreadWaked") - wakedBefore;
+
+    for (uint64_t i = 0; i < numberOfFibers; ++i)
+    {
+        futures[(pos + i) % numberOfFibers].wait();
+    }
+
+    state.counters["parks"] = benchmark::Counter(static_cast<double>(parked), benchmark::Counter::kAvgIterations);
+    state.counters["wakes"] = benchmark::Counter(static_cast<double>(waked), benchmark::Counter::kAvgIterations);
+    state.SetItemsProcessed(state.iterations());
+}
+
+// Injection from an active core: homeProcessor maps the caller's CPU to its own
+// processor, so the work lands on the ring of the scheduler thread pinned to that
+// same core. The injecting thread shares the logical CPU with that scheduler
+// thread.
+BENCHMARK_DEFINE_F(CpuSetBench, InjectFromActiveCpu)(benchmark::State & state)
+{
+    if (excludedCpu < 0)
+    {
+        state.SkipWithMessage("needs at least two available CPUs");
+        return;
+    }
+
+    pinToCpu(activeCpus.front());
+    injectFromCurrentCpu(state, static_cast<uint64_t>(state.range(0)));
+}
+BENCHMARK_REGISTER_F(CpuSetBench, InjectFromActiveCpu)->Arg(1)->Arg(16)->Arg(64);
+
+// Injection from the reserved core: the caller owns a core silk schedules nothing
+// on, and homeProcessor routes the work to an active processor's ring on another
+// core. Pairs with InjectFromActiveCpu at the same ring depth.
+BENCHMARK_DEFINE_F(CpuSetBench, InjectFromReservedCpu)(benchmark::State & state)
+{
+    if (excludedCpu < 0)
+    {
+        state.SkipWithMessage("needs at least two available CPUs");
+        return;
+    }
+
+    pinToCpu(excludedCpu);
+    injectFromCurrentCpu(state, static_cast<uint64_t>(state.range(0)));
+}
+BENCHMARK_REGISTER_F(CpuSetBench, InjectFromReservedCpu)->Arg(1)->Arg(16)->Arg(64);
+
+} // namespace silk
+
+// Whether the command line asks for the benchmark list. bb enumerates every
+// *-bench binary with the bare --benchmark_list_tests flag, and listing must not
+// pay for (or fail on) scheduler initialization.
+static bool isListOnlyRun(int argc, char ** argv) noexcept
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        int r = std::strcmp(argv[i], "--benchmark_list_tests");
+        if (!r)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+int main(int argc, char ** argv)
+{
+    if (isListOnlyRun(argc, argv))
+    {
+        benchmark::Initialize(&argc, argv);
+        benchmark::RunSpecifiedBenchmarks();
+        benchmark::Shutdown();
+        return 0;
+    }
+
+    silk::installCrashDumper();
+    silk::initialize();
+
+    cpu_set_t affinity;
+    CPU_ZERO(&affinity);
+    int r = ::sched_getaffinity(0, sizeof(affinity), &affinity);
+    if (r)
+    {
+        r = errno;
+        SILK_FAIL("could not read the process affinity mask: r=%d", r);
+    }
+
+    // Silk indexes per-CPU state by raw CPU id below the configured processor count, so only
+    // CPUs silk can address are considered.
+    uint32_t processorCount = silk::getProcessorCount();
+    std::vector<int> available;
+    for (uint32_t cpu = 0; cpu < processorCount; ++cpu)
+    {
+        if (CPU_ISSET(cpu, &affinity))
+        {
+            available.push_back(cpu);
+        }
+    }
+
+    silk::FiberScheduler::Options options;
+
+    // Reserve the highest available CPU: exclude it from silk's active set while
+    // it stays online so the benchmarks can migrate onto it.
+    if (available.size() >= 2)
+    {
+        silk::CpuSetBench::excludedCpu = available.back();
+        CPU_CLR(silk::CpuSetBench::excludedCpu, &options.cpuMask);
+        for (int cpu : available)
+        {
+            if (cpu != silk::CpuSetBench::excludedCpu)
+            {
+                silk::CpuSetBench::activeCpus.push_back(cpu);
+            }
+        }
+    }
+
+    silk::FiberScheduler::initialize(&options);
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+
+    silk::FiberScheduler::destroy();
+    silk::destroy();
+    return 0;
+}

--- a/src/fibers/cpu.cpp
+++ b/src/fibers/cpu.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 
 #include <fcntl.h>
+#include <pthread.h>
 #include <unistd.h>
 
 namespace silk
@@ -182,6 +183,20 @@ uint64_t topologyCostCycles(const CpuTopology & first, const CpuTopology & secon
     }
     // cross-NUMA ~500 us
     return Tsc::nanosecondsToCycles(500'000);
+}
+
+int pinThreadToCpus(const cpu_set_t & cpuSet) noexcept
+{
+    // pthread_setaffinity_np returns an error number directly (0 on success), not -1/errno.
+    return ::pthread_setaffinity_np(::pthread_self(), sizeof(cpuSet), &cpuSet);
+}
+
+int pinThreadToCpu(uint16_t cpu) noexcept
+{
+    cpu_set_t cpuSet;
+    CPU_ZERO(&cpuSet);
+    CPU_SET(cpu, &cpuSet);
+    return pinThreadToCpus(cpuSet);
 }
 
 } // namespace silk

--- a/src/fibers/cpu.h
+++ b/src/fibers/cpu.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include <sched.h>
+
 namespace silk
 {
 
@@ -30,5 +32,29 @@ uint64_t topologyCostCycles(const CpuTopology & first, const CpuTopology & secon
  * (pos - a) % d < c. Defaults are b=a, c=1, d=c. Exposed for unit tests.
  */
 bool cpuInCpulist(uint32_t cpu, const char * list) noexcept;
+
+/**
+ * Whether @p cpu belongs to the scheduler's active set: it must be in both the
+ * affinity mask @p affinityMask (the initializing thread's mask) and @p cpuMask.
+ */
+static inline bool isCpuActive(uint32_t cpu, const cpu_set_t & affinityMask, const cpu_set_t & cpuMask) noexcept
+{
+    return CPU_ISSET(cpu, &affinityMask) && CPU_ISSET(cpu, &cpuMask);
+}
+
+/**
+ * Pin the calling thread to the CPUs in @p cpuSet. The kernel migrates the
+ * thread off any excluded CPU before the call returns. Returns 0 or the errno
+ * from pthread_setaffinity_np.
+ */
+int pinThreadToCpus(const cpu_set_t & cpuSet) noexcept;
+
+/**
+ * Pin the calling thread to @p cpu. The kernel migrates the thread before the
+ * call returns, so on return the thread already runs on @p cpu and
+ * getCurrentProcessor observes it. Returns 0 or the errno from
+ * pthread_setaffinity_np.
+ */
+int pinThreadToCpu(uint16_t cpu) noexcept;
 
 } // namespace silk

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1144,6 +1144,11 @@ void FiberScheduler::initialize(const Options * userOptions) noexcept
     scheduler->waiterTableMask = options.waiterTableSize - 1;
 
     scheduler->processorCount = getProcessorCount();
+    SILK_ASSERT(
+        scheduler->processorCount <= kInvalidProcessorNumber,
+        "configured CPU count %d exceeds the supported maximum %d",
+        scheduler->processorCount,
+        kInvalidProcessorNumber);
     scheduler->processorState = std::make_unique<ProcessorState[]>(scheduler->processorCount);
 
     cpu_set_t processCpuSet;

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1065,6 +1065,16 @@ struct FiberScheduler::SchedulerState
     uint16_t schedulerThreadCount = 0;
     uint16_t workerThreadCount = 0;
 
+    // Maps every configured CPU to the processor a thread running there injects into:
+    // an active CPU to its own processor, an inactive CPU (excluded from the
+    // active set) to an active processor chosen round-robin, so work injected
+    // from a reserved core lands on a real ring instead of an uninitialized one.
+    std::unique_ptr<ProcessorState *[]> homeProcessor;
+
+    // The set of active CPUs. Worker threads pin to it so silk never runs
+    // fibers on reserved cores.
+    cpu_set_t activeMask;
+
     std::unique_ptr<std::thread[]> schedulerThreads;
     std::unique_ptr<std::thread[]> workerThreads;
 
@@ -1119,6 +1129,19 @@ void FiberScheduler::SchedulerState::parkThread() noexcept
     }
 }
 
+cpu_set_t FiberScheduler::Options::defaultCpuMask() noexcept
+{
+    cpu_set_t cpuSet;
+    CPU_ZERO(&cpuSet);
+
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu)
+    {
+        CPU_SET(cpu, &cpuSet);
+    }
+
+    return cpuSet;
+}
+
 void FiberScheduler::initialize(const Options * userOptions) noexcept
 {
     SILK_ASSERT(!scheduler);
@@ -1153,35 +1176,69 @@ void FiberScheduler::initialize(const Options * userOptions) noexcept
 
     cpu_set_t processCpuSet;
     CPU_ZERO(&processCpuSet);
-    sched_getaffinity(0, sizeof(processCpuSet), &processCpuSet);
+    int r = ::sched_getaffinity(0, sizeof(processCpuSet), &processCpuSet);
+    if (r)
+    {
+        r = errno;
+        SILK_FAIL("could not read the process affinity mask: r=%d", r);
+    }
 
-    scheduler->schedulerThreadCount = static_cast<uint16_t>(CPU_COUNT(&processCpuSet));
-    scheduler->schedulerThreads = std::make_unique<std::thread[]>(scheduler->schedulerThreadCount);
+    CPU_ZERO(&scheduler->activeMask);
+    scheduler->homeProcessor = std::make_unique<ProcessorState *[]>(scheduler->processorCount);
 
+    uint16_t activeCount = 0;
     for (uint16_t cpu = 0; cpu < scheduler->processorCount; ++cpu)
     {
-        if (CPU_ISSET(cpu, &processCpuSet))
+        if (isCpuActive(cpu, processCpuSet, options.cpuMask))
         {
-            ProcessorState * processor = &scheduler->processorState[cpu];
-            processor->number = cpu;
+            scheduler->processorState[cpu].number = cpu;
+            CPU_SET(cpu, &scheduler->activeMask);
+            ++activeCount;
         }
     }
+
+    SILK_ASSERT(activeCount > 0, "cpuMask excludes all affinity-mask cpus");
+
+    // Route every CPU to an active home: an active CPU to itself, an inactive
+    // one to an active CPU taken round-robin so injection from a reserved core
+    // spreads across the active rings instead of piling onto one.
+    uint16_t nextHome = 0;
+    for (uint16_t cpu = 0; cpu < scheduler->processorCount; ++cpu)
+    {
+        if (scheduler->processorState[cpu].number != kInvalidProcessorNumber)
+        {
+            scheduler->homeProcessor[cpu] = &scheduler->processorState[cpu];
+            continue;
+        }
+
+        while (scheduler->processorState[nextHome].number == kInvalidProcessorNumber)
+        {
+            nextHome = (nextHome + 1) % scheduler->processorCount;
+        }
+        scheduler->homeProcessor[cpu] = &scheduler->processorState[nextHome];
+        nextHome = (nextHome + 1) % scheduler->processorCount;
+    }
+
+    scheduler->schedulerThreadCount = activeCount;
+    scheduler->schedulerThreads = std::make_unique<std::thread[]>(scheduler->schedulerThreadCount);
 
     buildStealCandidates();
 
+    // From here on the active set is read from activeMask, never from
+    // ProcessorState::number: a started scheduler thread writes its own number in
+    // ProcessorState::initialize, so reading it from this thread would race.
     uint16_t threadIndex = 0;
     for (uint16_t cpu = 0; cpu < scheduler->processorCount; ++cpu)
     {
-        if (CPU_ISSET(cpu, &processCpuSet))
+        if (CPU_ISSET(cpu, &scheduler->activeMask))
         {
-            ProcessorState * processor = &scheduler->processorState[cpu];
-            scheduler->schedulerThreads[threadIndex++] = std::thread(runScheduler, processor);
+            scheduler->schedulerThreads[threadIndex++] = std::thread(runScheduler, &scheduler->processorState[cpu]);
         }
     }
 
     for (uint16_t cpu = 0; cpu < scheduler->processorCount; ++cpu)
     {
-        if (CPU_ISSET(cpu, &processCpuSet))
+        if (CPU_ISSET(cpu, &scheduler->activeMask))
         {
             ProcessorState * processor = &scheduler->processorState[cpu];
             while (!processor->initialized.load(std::memory_order_acquire))
@@ -1353,13 +1410,24 @@ bool FiberScheduler::isFiberRunning(Fiber * fiber) noexcept
     return fiber->state.load(std::memory_order_acquire) == FiberState::RUNNING;
 }
 
+// The processor a caller on the current CPU injects work into: its own processor
+// if the CPU runs a scheduler thread, otherwise the active home mapped in
+// initialize. This keeps injection from a reserved core off the uninitialized
+// ring of an inactive CPU (which would index out of bounds at
+// kInvalidProcessorNumber). Re-reads the current CPU fresh on every call - never
+// cache it across a suspension.
+FiberScheduler::ProcessorState * FiberScheduler::currentProcessor() noexcept
+{
+    return scheduler->homeProcessor[getCurrentProcessor()];
+}
+
 Fiber *
 FiberScheduler::allocateFiber(FiberMain * fiberMain, FiberParametersDtor * parametersDtor, uint8_t category, FiberFuture * future) noexcept
 {
     Fiber * fiber = scheduler->fiberPool.allocate();
     if (fiber)
     {
-        ProcessorState * processor = &scheduler->processorState[getCurrentProcessor()];
+        ProcessorState * processor = currentProcessor();
         FiberId fiberId = processor->allocateFiberId(category);
 
         if (fiber->initialize(fiberId, fiberMain, parametersDtor, future))
@@ -1386,7 +1454,7 @@ bool FiberScheduler::schedule(Fiber * fiber) noexcept
 {
     if (fiber->tryChangeStateToReady())
     {
-        ProcessorState * processor = &scheduler->processorState[getCurrentProcessor()];
+        ProcessorState * processor = currentProcessor();
         ProcessorState * target = enqueueReady(processor, fiber);
         if (target)
         {
@@ -1400,8 +1468,9 @@ bool FiberScheduler::schedule(Fiber * fiber) noexcept
 
 // Shared by schedule, scheduleAll, and runFiber: place a ready fiber on its home ready queue and return
 // the processor whose doorbell the caller must ring (immediately, or batched). processor is the caller's
-// own processor - used as the home default and, by the caller, as the doorbell source - so it must be the
-// current processor. A proxy or thread-mode fiber, or a full ready queue, rings its own wakeup here and
+// injection processor (the current CPU's own processor, or its active home when the current CPU is outside
+// the active set) - used as the home default and, by the caller, as the doorbell source - so it must come
+// from currentProcessor. A proxy or thread-mode fiber, or a full ready queue, rings its own wakeup here and
 // returns null.
 FiberScheduler::ProcessorState * FiberScheduler::enqueueReady(ProcessorState * processor, Fiber * fiber) noexcept
 {
@@ -1444,7 +1513,7 @@ FiberScheduler::ProcessorState * FiberScheduler::enqueueReady(ProcessorState * p
 
 void FiberScheduler::scheduleAll(Fiber ** fibers, uint64_t count) noexcept
 {
-    ProcessorState * processor = &scheduler->processorState[getCurrentProcessor()];
+    ProcessorState * processor = currentProcessor();
 
     // Dedup the wake targets in a bitmap over all processors so each parked target is rung exactly once.
     uint64_t words[Bitmap::wordCount(kInvalidProcessorNumber)];
@@ -1612,7 +1681,7 @@ void FiberScheduler::enqueueIo(IoFuture * future, Setup && setup) noexcept
     {
         // Re-fetch processor on each iteration: if the SQ ring was full and we
         // yielded, the fiber may have been stolen and now runs on a different CPU.
-        processor = &scheduler->processorState[getCurrentProcessor()];
+        processor = currentProcessor();
         if (processor->enqueueIo(future, std::forward<Setup>(setup)))
         {
             break;
@@ -1710,7 +1779,7 @@ void FiberScheduler::cancelIo(IoFuture * future) noexcept
     uint16_t processorNumber = future->processorNumber;
     if (processorNumber == kInvalidProcessorNumber)
     {
-        processorNumber = getCurrentProcessor();
+        processorNumber = currentProcessor()->number;
     }
 
     ProcessorState * processor = &scheduler->processorState[processorNumber];
@@ -1747,7 +1816,7 @@ void FiberScheduler::sleep(uint64_t nanoseconds, SleepFuture * future) noexcept
     }
 
     future->deadlineCycles = Tsc::getCycles() + Tsc::nanosecondsToCycles(nanoseconds);
-    future->processorNumber = getCurrentProcessor();
+    future->processorNumber = currentProcessor()->number;
 
     ProcessorState * processor = &scheduler->processorState[future->processorNumber];
     processor->sleepQueue.push(future);
@@ -1803,10 +1872,8 @@ LatencyReport FiberScheduler::reportLatency(ProfileEventKind kind, uint8_t categ
 
 void FiberScheduler::runScheduler(ProcessorState * processor) noexcept
 {
-    cpu_set_t cpuSet;
-    CPU_ZERO(&cpuSet);
-    CPU_SET(processor->number, &cpuSet);
-    ::pthread_setaffinity_np(::pthread_self(), sizeof(cpuSet), &cpuSet);
+    int r = pinThreadToCpu(processor->number);
+    SILK_ASSERT(!r, "could not pin the scheduler thread to its cpu: r=%d", r);
 
     // Initialize per-CPU resources pinned to this CPU so that mmap'd memory
     // (io_uring rings, eventfd) is allocated on the local NUMA node.
@@ -2283,7 +2350,8 @@ void FiberScheduler::runFiber(Fiber * fiber, CpuTimer * timer) noexcept
 
     // Only the per-CPU scheduler thread (timer != nullptr) reports profile events:
     // it is pinned and is the sole producer of this CPU's SPSC ring. Worker threads
-    // (timer == nullptr) are unpinned and would break the single-producer rule.
+    // (timer == nullptr) migrate within the active set and would break the
+    // single-producer rule.
     uint64_t runStartCycles = 0;
     if (timer)
     {
@@ -2337,8 +2405,8 @@ void FiberScheduler::runFiber(Fiber * fiber, CpuTimer * timer) noexcept
 
     // Submit any SQEs the fiber enqueued. On the per-CPU scheduler thread
     // (timer != nullptr) use pressure-relief mode so the dispatch loop can
-    // amortize the syscall across multiple fibers; on unpinned worker threads
-    // there is no batching boundary, so force-submit per fiber.
+    // amortize the syscall across multiple fibers; on worker threads there is
+    // no batching boundary, so force-submit per fiber.
     processor->submitIo(timer == nullptr);
 
     FiberState fiberState = fiber->state.load(std::memory_order_acquire);
@@ -2400,6 +2468,11 @@ void FiberScheduler::runFiber(Fiber * fiber, CpuTimer * timer) noexcept
 
 void FiberScheduler::runThreadWorker() noexcept
 {
+    // Confine the overflow pool to the active CPUs so silk never runs a fiber on
+    // a reserved core, and so a worker never injects from an inactive CPU.
+    int r = pinThreadToCpus(scheduler->activeMask);
+    SILK_ASSERT(!r, "could not pin the worker thread to the active cpu set: r=%d", r);
+
     while (!scheduler->stopping.load(std::memory_order_relaxed))
     {
         while (Fiber * fiber = scheduler->readyQueue.dequeue())

--- a/src/fibers/tests/CMakeLists.txt
+++ b/src/fibers/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS *.cpp)
 
+# fiber-cpuset-test is its own executable: it needs a main that restricts the scheduler
+# to a CPU subset before running, so it cannot share fibers-test's global init.
+list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fiber-cpuset-test.cpp)
+
 add_executable(fibers-test ${TEST_SOURCES})
 target_link_libraries(fibers-test PRIVATE silk-fibers GTest::gtest)
 
@@ -9,4 +13,9 @@ target_link_libraries(fibers-test PRIVATE silk-fibers GTest::gtest)
 # On a test timeout ctest sends SIGQUIT (caught by the crash-dumper installed in main) and waits the grace
 # period for the gdb dump, instead of the default uncatchable SIGKILL.
 gtest_discover_tests(fibers-test
+    PROPERTIES RESOURCE_LOCK iouring TIMEOUT_SIGNAL_NAME SIGQUIT TIMEOUT_SIGNAL_GRACE_PERIOD 60)
+
+add_executable(fibers-cpuset-test fiber-cpuset-test.cpp)
+target_link_libraries(fibers-cpuset-test PRIVATE silk-fibers GTest::gtest)
+gtest_discover_tests(fibers-cpuset-test
     PROPERTIES RESOURCE_LOCK iouring TIMEOUT_SIGNAL_NAME SIGQUIT TIMEOUT_SIGNAL_GRACE_PERIOD 60)

--- a/src/fibers/tests/cpu-test.cpp
+++ b/src/fibers/tests/cpu-test.cpp
@@ -1,5 +1,6 @@
 #include <fibers/cpu.h>
 
+#include <silk/fibers/fiber.h>
 #include <silk/util/platform.h>
 #include <silk/util/tsc.h>
 
@@ -159,6 +160,98 @@ TEST(CpuTopology, readDoesNotCrash)
 
     // Only assert the call completed without crashing; sysfs entries may be
     // absent in containers so we make no assertion about the topology values.
+}
+
+// isCpuActive: the default cpuMask (all CPUs set) admits exactly the affinity mask.
+TEST(CpuActive, defaultMaskFollowsAffinityMask)
+{
+    cpu_set_t affinityMask;
+    CPU_ZERO(&affinityMask);
+    CPU_SET(1, &affinityMask);
+    CPU_SET(3, &affinityMask);
+
+    FiberScheduler::Options options;
+
+    bool b = isCpuActive(1, affinityMask, options.cpuMask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(3, affinityMask, options.cpuMask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(0, affinityMask, options.cpuMask);
+    ASSERT_FALSE(b);
+    b = isCpuActive(2, affinityMask, options.cpuMask);
+    ASSERT_FALSE(b);
+}
+
+// isCpuActive: a cpuMask narrows the active set within the affinity mask.
+TEST(CpuActive, cpuMaskNarrows)
+{
+    cpu_set_t affinityMask;
+    CPU_ZERO(&affinityMask);
+    for (uint32_t cpu = 0; cpu < 4; ++cpu)
+    {
+        CPU_SET(cpu, &affinityMask);
+    }
+
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(1, &mask);
+    CPU_SET(2, &mask);
+
+    bool b = isCpuActive(1, affinityMask, mask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(2, affinityMask, mask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(0, affinityMask, mask);
+    ASSERT_FALSE(b);
+    b = isCpuActive(3, affinityMask, mask);
+    ASSERT_FALSE(b);
+}
+
+// isCpuActive: a cpu outside the affinity mask is never active, even if its
+// cpuMask bit is set.
+TEST(CpuActive, outsideAffinityMaskStaysInactive)
+{
+    cpu_set_t affinityMask;
+    CPU_ZERO(&affinityMask);
+    CPU_SET(1, &affinityMask);
+
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(1, &mask);
+    CPU_SET(5, &mask);
+
+    bool b = isCpuActive(1, affinityMask, mask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(5, affinityMask, mask);
+    ASSERT_FALSE(b);
+}
+
+// isCpuActive: a gapped cpuMask admits only its set bits.
+TEST(CpuActive, gappedMask)
+{
+    cpu_set_t affinityMask;
+    CPU_ZERO(&affinityMask);
+    for (uint32_t cpu = 0; cpu < 10; ++cpu)
+    {
+        CPU_SET(cpu, &affinityMask);
+    }
+
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(0, &mask);
+    CPU_SET(4, &mask);
+    CPU_SET(9, &mask);
+
+    bool b = isCpuActive(0, affinityMask, mask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(4, affinityMask, mask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(9, affinityMask, mask);
+    ASSERT_TRUE(b);
+    b = isCpuActive(1, affinityMask, mask);
+    ASSERT_FALSE(b);
+    b = isCpuActive(8, affinityMask, mask);
+    ASSERT_FALSE(b);
 }
 
 } // namespace silk

--- a/src/fibers/tests/fiber-cpuset-test.cpp
+++ b/src/fibers/tests/fiber-cpuset-test.cpp
@@ -1,0 +1,315 @@
+#include <silk/fibers/fiber.h>
+#include <silk/util/assert.h>
+#include <silk/util/crash-dumper.h>
+#include <silk/util/init.h>
+#include <silk/util/platform.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <vector>
+
+#include <poll.h>
+#include <sched.h>
+#include <unistd.h>
+
+#include <fibers/cpu.h>
+
+namespace silk
+{
+
+/**
+ * The scheduler is restricted to a strict subset of the available CPUs, leaving
+ * excludedCpu online but off the active set. The tests migrate onto it and drive
+ * silk from there, exercising the injection redirect for a thread on a reserved
+ * core.
+ */
+class CpuSetTest : public ::testing::Test
+{
+protected:
+    /** Fiber entry: record the CPU the fiber runs on. */
+    static int recordCpuFiber(int ** recordedCpu) noexcept
+    {
+        **recordedCpu = getCurrentProcessor();
+        return 0;
+    }
+
+    /** Fiber entry: enter thread mode (moving to the worker pool) and record the CPU the worker runs the fiber on. */
+    static int threadModeCpuFiber(int ** recordedCpu) noexcept
+    {
+        FiberScheduler::ThreadModeScope scope;
+        **recordedCpu = getCurrentProcessor();
+        return 0;
+    }
+
+    /** Move the calling thread onto the excluded core. */
+    static void pinToExcludedCpu() noexcept
+    {
+        int r = pinThreadToCpu(static_cast<uint16_t>(excludedCpu));
+        ASSERT_EQ(r, 0);
+    }
+
+    /** Whether @p cpu is in the scheduler's active set. */
+    static bool isActiveCpu(int cpu) noexcept { return std::find(activeCpus.begin(), activeCpus.end(), cpu) != activeCpus.end(); }
+
+public:
+    /** CPUs in the scheduler's active set. Populated by main. */
+    static std::vector<int> activeCpus;
+
+    /** The reserved CPU. Populated by main; -1 when there are too few CPUs to reserve one, and every test skips. */
+    static int excludedCpu;
+};
+
+std::vector<int> CpuSetTest::activeCpus;
+int CpuSetTest::excludedCpu = -1;
+
+// Spawning a fiber from a thread on an excluded core must complete and the fiber
+// must run on an active core, never the excluded one - proving the injection
+// redirect avoids the uninitialized ring / out-of-bounds processor index.
+TEST_F(CpuSetTest, runFromExcludedCoreRunsOnActiveCore)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    int fiberCpu = -1;
+    int r = FiberScheduler::run(recordCpuFiber, &fiberCpu);
+    ASSERT_EQ(r, 0);
+    ASSERT_NE(fiberCpu, excludedCpu);
+
+    bool b = isActiveCpu(fiberCpu);
+    ASSERT_TRUE(b);
+}
+
+// A proxy thread on an excluded core can sleep through silk: sleep routes the
+// SleepFuture to an active home processor and is woken from there.
+TEST_F(CpuSetTest, sleepFromExcludedCoreCompletes)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    FiberScheduler::sleep(1'000'000);
+}
+
+// Blocking pipe IO driven from a proxy thread on an excluded core: enqueueIo
+// redirects the SQEs to an active home ring and force-submits them there.
+TEST_F(CpuSetTest, ioFromExcludedCoreCompletes)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    int fds[2];
+    int r = ::pipe(fds);
+    ASSERT_EQ(r, 0);
+
+    const char message[] = "cpuset";
+    uint64_t bytesWritten = 0;
+    r = FiberScheduler::write(fds[1], message, sizeof(message), 0, &bytesWritten);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(bytesWritten, sizeof(message));
+
+    char buf[sizeof(message)] = {};
+    uint64_t bytesRead = 0;
+    r = FiberScheduler::read(fds[0], buf, sizeof(buf), 0, &bytesRead);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(bytesRead, sizeof(message));
+    ASSERT_STREQ(buf, message);
+
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// cancelIo from an excluded core must reach the same active ring that holds the
+// poll SQE; a cross-ring cancel fails with -ENOENT and leaves wait hung.
+TEST_F(CpuSetTest, cancelIoFromExcludedCoreCompletes)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    int fds[2];
+    int r = ::pipe(fds);
+    ASSERT_EQ(r, 0);
+
+    FiberScheduler::IoFuture pollFuture;
+    FiberScheduler::poll(fds[0], POLLIN, nullptr, &pollFuture);
+    pollFuture.cancel();
+
+    // POLLIN on an empty pipe with the write end open can only complete through
+    // the cancellation.
+    r = pollFuture.wait();
+    ASSERT_EQ(r, ECANCELED);
+
+    ::close(fds[0]);
+    ::close(fds[1]);
+}
+
+// Thread-mode fibers run on the worker pool, which is pinned to the active set -
+// a thread-mode slice never lands on the excluded core.
+TEST_F(CpuSetTest, threadModeFromExcludedCoreStaysOnActiveCores)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    for (int i = 0; i < 32; ++i)
+    {
+        int fiberCpu = -1;
+        int r = FiberScheduler::run(threadModeCpuFiber, &fiberCpu);
+        ASSERT_EQ(r, 0);
+        ASSERT_NE(fiberCpu, excludedCpu);
+
+        bool b = isActiveCpu(fiberCpu);
+        ASSERT_TRUE(b);
+    }
+}
+
+// setAll from an excluded core batches the wakeups through scheduleAll: the
+// doorbell SQEs are filled and submitted on the caller's home ring, and every
+// woken fiber resumes on an active core.
+TEST_F(CpuSetTest, setAllFromExcludedCoreWakesFibersOnActiveCores)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    struct Params
+    {
+        FiberFuture * waitFuture;
+        int * resumedCpu;
+
+        static int fiberMain(Params * params) noexcept
+        {
+            params->waitFuture->wait();
+            *params->resumedCpu = getCurrentProcessor();
+            return 0;
+        }
+    };
+
+    constexpr uint64_t count = 16;
+    FiberFuture waitFutures[count];
+    FiberFuture doneFutures[count];
+    FiberFuture * waitPointers[count];
+    int resumedCpus[count] = {};
+
+    for (uint64_t i = 0; i < count; ++i)
+    {
+        int r = FiberScheduler::run(Params::fiberMain, Params{&waitFutures[i], &resumedCpus[i]}, &doneFutures[i]);
+        ASSERT_EQ(r, 0);
+        waitPointers[i] = &waitFutures[i];
+    }
+
+    FiberFuture::setAll(0, waitPointers, count);
+
+    for (uint64_t i = 0; i < count; ++i)
+    {
+        int r = doneFutures[i].wait();
+        ASSERT_EQ(r, 0);
+
+        bool b = isActiveCpu(resumedCpus[i]);
+        ASSERT_TRUE(b);
+    }
+}
+
+// Many fibers injected from an excluded core all run on active cores - the
+// only-allowed-cores property observed through the public API.
+TEST_F(CpuSetTest, manyFibersFromExcludedCoreStayOnActiveCores)
+{
+    if (excludedCpu < 0)
+    {
+        GTEST_SKIP() << "needs at least two available CPUs";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(pinToExcludedCpu());
+
+    for (int i = 0; i < 128; ++i)
+    {
+        int fiberCpu = -1;
+        int r = FiberScheduler::run(recordCpuFiber, &fiberCpu);
+        ASSERT_EQ(r, 0);
+
+        bool b = isActiveCpu(fiberCpu);
+        ASSERT_TRUE(b);
+    }
+}
+
+} // namespace silk
+
+int main(int argc, char ** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    if (::testing::GTEST_FLAG(list_tests))
+    {
+        return RUN_ALL_TESTS();
+    }
+
+    silk::installCrashDumper();
+    silk::initialize();
+
+    cpu_set_t affinity;
+    CPU_ZERO(&affinity);
+    int r = ::sched_getaffinity(0, sizeof(affinity), &affinity);
+    if (r)
+    {
+        r = errno;
+        SILK_FAIL("could not read the process affinity mask: r=%d", r);
+    }
+
+    // Silk indexes per-CPU state by raw CPU id below the configured processor count, so only
+    // CPUs silk can address are considered.
+    uint32_t processorCount = silk::getProcessorCount();
+    std::vector<int> available;
+    for (uint32_t cpu = 0; cpu < processorCount; ++cpu)
+    {
+        if (CPU_ISSET(cpu, &affinity))
+        {
+            available.push_back(cpu);
+        }
+    }
+
+    silk::FiberScheduler::Options options;
+
+    // Reserve the highest available CPU: exclude it from silk's active set while
+    // it stays online so the tests can migrate onto it.
+    if (available.size() >= 2)
+    {
+        silk::CpuSetTest::excludedCpu = available.back();
+        CPU_CLR(silk::CpuSetTest::excludedCpu, &options.cpuMask);
+        for (int cpu : available)
+        {
+            if (cpu != silk::CpuSetTest::excludedCpu)
+            {
+                silk::CpuSetTest::activeCpus.push_back(cpu);
+            }
+        }
+    }
+
+    silk::FiberScheduler::initialize(&options);
+
+    r = RUN_ALL_TESTS();
+
+    silk::FiberScheduler::destroy();
+    silk::destroy();
+    return r;
+}

--- a/src/fibers/tests/fiber-test.cpp
+++ b/src/fibers/tests/fiber-test.cpp
@@ -214,7 +214,7 @@ TEST(Fiber, runWithCategoryStampsUpperByte)
 // the test asserts that at least two distinct CPUs appear.
 TEST(Fiber, WorkStealing)
 {
-    if (getProcessorCount() < 2)
+    if (getAvailableProcessorCount() < 2)
     {
         GTEST_SKIP() << "requires at least 2 CPUs";
     }

--- a/src/fibers/tests/sequencer-test.cpp
+++ b/src/fibers/tests/sequencer-test.cpp
@@ -2,6 +2,7 @@
 
 #include <silk/fibers/fiber.h>
 #include <silk/fibers/future.h>
+#include <silk/util/sanitizers.h>
 
 #include <gtest/gtest.h>
 
@@ -539,6 +540,16 @@ TEST(FiberSequencer, lostWakeupUnderContention)
     const uint32_t threads = std::min(8u, cores); // incrementers, and the waiter's (final) token
 
     uint64_t iters = 200'000;
+#if defined(__SANITIZE_THREAD__)
+    // The high count is what reproduces the StoreLoad reordering this test
+    // asserts on, but TSan cannot observe that reordering: it detects data races
+    // through a happens-before model, and a missing StoreLoad fence between
+    // atomics is a memory-model bug, not a race. So the full count buys no
+    // coverage under TSan while costing about 6 ms per iteration on an 8-CPU box,
+    // pushing the run past the ctest timeout. A small count still drives the same
+    // paths for TSan's race detection, which saturates in far fewer iterations.
+    iters = 2'000;
+#endif
     if (const char * env = std::getenv("SILK_SEQ_LITMUS_ITERS"))
     {
         iters = std::strtoull(env, nullptr, 10);


### PR DESCRIPTION
## What

`Options::cpuMask` reserves CPUs for other activity: the active set is the affinity mask of the thread calling `initialize` intersected with `cpuMask` (a `cpu_set_t` with every CPU set by default; reserve a CPU by clearing its bit), and scheduler threads and the thread-mode worker pool start and pin only on active CPUs.

`homeProcessor` maps every online CPU to an active processor (itself when active, round-robin otherwise), and `currentProcessor` routes all injection through it, so a thread on a reserved core can run, schedule, sleep, and do IO without indexing the uninitialized ring of an inactive CPU.

## Cost

The redirect adds one dependent L1 load on the injection path (verified by disassembly); a fibers-bench A/B against main shows no regression above measurement noise.

`fibers-cpuset-bench` (added here) prices the two operating points. On an 8-vCPU Icelake VM (SMT sibling of the reserved core stays active — numbers indicative only): reserving a core is ~4x better for pipelined injection (343 vs 1288 ns at ring depth 16) and ~2.3x worse for serial request-response (13.6 vs 6.0 us at depth 1). The latency cost is inherent to reserving — the injector's core hosts no scheduler thread, and the remote home parks at low injection rates.

## Tests

- `cpu-test.cpp`: unit coverage for `isCpuActive`.
- `cpuset-test.cpp`: a separate executable (needs a `main` that restricts the scheduler to a CPU subset before running); drives spawn, sleep, IO, `cancelIo`, thread mode, and `setAll` from a reserved core.

All pass on Linux x86-64 (kernel 6.8, clang 21).

