### PR TITLE
Patch vendored Poco Format.cpp to resolve std::format ambiguity

### DIFF
--- a/contrib/poco-cmake/CMakeLists.txt
+++ b/contrib/poco-cmake/CMakeLists.txt
@@ -3,6 +3,20 @@ set(POCO_SRC ${CMAKE_SOURCE_DIR}/contrib/poco)
 find_package(ZLIB REQUIRED)
 find_package(double-conversion REQUIRED)
 
+# Patches are applied to copies in the build dir so the submodule stays clean.
+function(poco_patch_source module stem)
+    execute_process(
+        COMMAND patch
+        -o ${CMAKE_CURRENT_BINARY_DIR}/${stem}.cpp
+        ${POCO_SRC}/${module}/src/${stem}.cpp
+        INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/patches/${stem}.patch
+        RESULT_VARIABLE _patch_result
+    )
+    if(NOT _patch_result EQUAL 0)
+        message(FATAL_ERROR "Failed to patch ${stem}.cpp (exit code ${_patch_result})")
+    endif()
+endfunction()
+
 # PCRE - bundled regex library in Foundation
 file(GLOB POCO_PCRE_SRCS ${POCO_SRC}/Foundation/src/pcre_*.c)
 add_library(_poco_foundation_pcre ${POCO_PCRE_SRCS})
@@ -13,6 +27,11 @@ target_compile_options(_poco_foundation_pcre PRIVATE -w)
 file(GLOB POCO_FOUNDATION_SRCS ${POCO_SRC}/Foundation/src/*.cpp)
 list(FILTER POCO_FOUNDATION_SRCS EXCLUDE REGEX
     ".*_(UNIX|POSIX|WIN32|WIN32U|WINCE|VX|DEC|HPUX|QNX|SUN|STD|DUMMY|C99|Android)\\.cpp$|.*(EventLogChannel|WindowsConsoleChannel)\\.cpp$")
+
+# Format.cpp - its unqualified format calls are ambiguous with std::format found by ADL
+poco_patch_source(Foundation Format)
+list(FILTER POCO_FOUNDATION_SRCS EXCLUDE REGEX ".*/Foundation/src/Format\\.cpp$")
+list(APPEND POCO_FOUNDATION_SRCS ${CMAKE_CURRENT_BINARY_DIR}/Format.cpp)
 
 add_library(_poco_foundation ${POCO_FOUNDATION_SRCS})
 add_library(Poco::Foundation ALIAS _poco_foundation)
@@ -32,7 +51,6 @@ target_link_libraries(_poco_foundation PRIVATE
 )
 
 # Net - patch stream files that use a shared MemoryPool (mutex contention at high concurrency)
-# Patches are applied to copies in the build dir so the submodule stays clean.
 set(POCO_NET_PATCHED_FILES
     HTTPBufferAllocator
     HTTPFixedLengthStream
@@ -42,16 +60,7 @@ set(POCO_NET_PATCHED_FILES
 )
 
 foreach(stem IN LISTS POCO_NET_PATCHED_FILES)
-    execute_process(
-        COMMAND patch
-        -o ${CMAKE_CURRENT_BINARY_DIR}/${stem}.cpp
-        ${POCO_SRC}/Net/src/${stem}.cpp
-        INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/patches/${stem}.patch
-        RESULT_VARIABLE _patch_result
-    )
-    if(_patch_result GREATER 1)
-        message(FATAL_ERROR "Failed to patch ${stem}.cpp (exit code ${_patch_result})")
-    endif()
+    poco_patch_source(Net ${stem})
 endforeach()
 
 file(GLOB POCO_NET_SRCS ${POCO_SRC}/Net/src/*.cpp)

--- a/contrib/poco-cmake/patches/Format.patch
+++ b/contrib/poco-cmake/patches/Format.patch
@@ -1,0 +1,92 @@
+--- contrib/poco/Foundation/src/Format.cpp	2026-05-15 20:35:56.227757039 +0000
++++ contrib/poco-cmake/patches/Format.cpp.new	2026-07-23 18:12:03.457035646 +0000
+@@ -309,7 +309,7 @@
+ {
+ 	std::vector<Any> args;
+ 	args.push_back(value);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -318,7 +318,7 @@
+ 	std::vector<Any> args;
+ 	args.push_back(value1);
+ 	args.push_back(value2);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -328,7 +328,7 @@
+ 	args.push_back(value1);
+ 	args.push_back(value2);
+ 	args.push_back(value3);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -339,7 +339,7 @@
+ 	args.push_back(value2);
+ 	args.push_back(value3);
+ 	args.push_back(value4);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -351,7 +351,7 @@
+ 	args.push_back(value3);
+ 	args.push_back(value4);
+ 	args.push_back(value5);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -364,7 +364,7 @@
+ 	args.push_back(value4);
+ 	args.push_back(value5);
+ 	args.push_back(value6);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -378,7 +378,7 @@
+ 	args.push_back(value5);
+ 	args.push_back(value6);
+ 	args.push_back(value7);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -393,7 +393,7 @@
+ 	args.push_back(value6);
+ 	args.push_back(value7);
+ 	args.push_back(value8);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -409,7 +409,7 @@
+ 	args.push_back(value7);
+ 	args.push_back(value8);
+ 	args.push_back(value9);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 
+@@ -426,7 +426,7 @@
+ 	args.push_back(value8);
+ 	args.push_back(value9);
+ 	args.push_back(value10);
+-	format(result, fmt, args);
++	Poco::format(result, fmt, args);
+ }
+ 
+ 


### PR DESCRIPTION
Poco 1.9.3's Format.cpp makes unqualified recursive format calls whose std::string and std::vector<Any> arguments let ADL find std::format, making the calls ambiguous under C++23 with libstdc++ 15. Add a configure-time patch that qualifies the ten affected calls as Poco::format, and extract the Net patch invocation into a poco_patch_source function shared by the Foundation and Net targets.