### PR TITLE
Remove nodiscard requirement from FiberSequencer::advance

### DIFF
--- a/include/silk/fibers/event.h
+++ b/include/silk/fibers/event.h
@@ -21,13 +21,13 @@ public:
     bool isSet() const noexcept { return sequencer.get() & 1; }
 
     /** Signal the event and wake all current waiters. No-op if already set. */
-    void set() noexcept { (void)sequencer.advance(sequencer.get() | 1); }
+    void set() noexcept { sequencer.advance(sequencer.get() | 1); }
 
     /** Clear the event. No-op if already unset. */
     void reset() noexcept
     {
         uint64_t current = sequencer.get();
-        (void)sequencer.advance(current + (current & 1));
+        sequencer.advance(current + (current & 1));
     }
 
     /** Wait until the event is set, blocking the calling fiber. */

--- a/include/silk/fibers/sequencer.h
+++ b/include/silk/fibers/sequencer.h
@@ -107,7 +107,7 @@ public:
      * Wakes all futures whose token is now reached.
      * Returns true if the counter was advanced, false if it was already >= @p value.
      */
-    [[nodiscard]] bool advance(uint64_t value) noexcept
+    bool advance(uint64_t value) noexcept
     {
         uint64_t current = counter.load(std::memory_order_relaxed);
         for (;;)


### PR DESCRIPTION
This is too restrictive - very often clients do not care about a result.