### PR TITLE
Move values through BoundedQueue slots

### DIFF
--- a/include/silk/util/bounded-queue.h
+++ b/include/silk/util/bounded-queue.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <utility>
 
 namespace silk
 {
@@ -70,7 +71,7 @@ public:
             {
                 if (enqueuePos.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
                 {
-                    slot.value = value;
+                    slot.value = std::move(value);
                     slot.sequence.store(pos + 1, std::memory_order_release);
                     return true;
                 }
@@ -102,7 +103,7 @@ public:
             {
                 if (dequeuePos.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
                 {
-                    *value = slot.value;
+                    *value = std::move(slot.value);
                     slot.sequence.store(pos + mask + 1, std::memory_order_release);
                     return true;
                 }

--- a/src/util/tests/bounded-queue-test.cpp
+++ b/src/util/tests/bounded-queue-test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -83,6 +84,30 @@ TEST(BoundedQueue, ReusableAfterDrain)
         EXPECT_TRUE(queue.dequeue(&value));
     }
     EXPECT_TRUE(queue.empty());
+}
+
+TEST(BoundedQueue, MovesValuesThroughSlots)
+{
+    BoundedQueue<std::shared_ptr<int>> queue{4};
+
+    std::shared_ptr<int> source = std::make_shared<int>(42);
+    std::weak_ptr<int> observer = source;
+
+    bool b = queue.enqueue(std::move(source));
+    ASSERT_TRUE(b);
+
+    std::shared_ptr<int> result;
+    b = queue.dequeue(&result);
+    ASSERT_TRUE(b);
+    ASSERT_EQ(*result, 42);
+
+    // The slot releases its reference at hand-off - result is the sole owner.
+    long useCount = observer.use_count();
+    ASSERT_EQ(useCount, 1);
+
+    result.reset();
+    b = observer.expired();
+    ASSERT_TRUE(b);
 }
 
 TEST(BoundedQueue, ConcurrentEnqueue)


### PR DESCRIPTION
enqueue moved from its by-value parameter into the slot and dequeue moved the slot value out, where both previously copied. A dequeued slot no longer retains a copy until its next lap, so a T holding a reference (a shared pointer) releases it at hand-off; enqueue's retry-on-full callers keep their argument intact either way.