### PR TITLE
Add waitCycles to waitForMultiple and waitWithTimeout

### DIFF
--- a/include/silk/fibers/future.h
+++ b/include/silk/fibers/future.h
@@ -101,9 +101,10 @@ public:
      *
      * @param futureArray     Array of futures to watch.
      * @param futureArraySize Number of futures in the array.
+     * @param waitCycles      Optional accumulator for cycles spent suspended.
      * @return                Index of a future that is set on return.
      */
-    static uint64_t waitForMultiple(FiberFuture ** futureArray, uint64_t futureArraySize) noexcept;
+    static uint64_t waitForMultiple(FiberFuture ** futureArray, uint64_t futureArraySize, uint64_t * waitCycles = nullptr) noexcept;
 
     /**
      * Wait for @p future with a timeout. Blocks until @p future is set or
@@ -115,8 +116,9 @@ public:
      *
      * @param future      Future to wait on.
      * @param nanoseconds Maximum time to wait in nanoseconds.
+     * @param waitCycles  Optional accumulator for cycles spent suspended.
      */
-    [[nodiscard]] static int waitWithTimeout(FiberFuture * future, uint64_t nanoseconds) noexcept;
+    [[nodiscard]] static int waitWithTimeout(FiberFuture * future, uint64_t nanoseconds, uint64_t * waitCycles = nullptr) noexcept;
 
     /**
      * Set the same result on a batch of futures and wake their waiters together. Equivalent to calling

--- a/src/fibers/future.cpp
+++ b/src/fibers/future.cpp
@@ -122,7 +122,7 @@ void FiberFuture::suspendCallback(Fiber * fiber, FiberFuture * future) noexcept
     }
 }
 
-uint64_t FiberFuture::waitForMultiple(FiberFuture ** futureArray, uint64_t futureArraySize) noexcept
+uint64_t FiberFuture::waitForMultiple(FiberFuture ** futureArray, uint64_t futureArraySize, uint64_t * waitCycles) noexcept
 {
     if (futureArraySize == 0)
     {
@@ -130,7 +130,7 @@ uint64_t FiberFuture::waitForMultiple(FiberFuture ** futureArray, uint64_t futur
     }
     if (futureArraySize == 1)
     {
-        futureArray[0]->wait();
+        futureArray[0]->wait(waitCycles);
         return 0;
     }
 
@@ -164,7 +164,7 @@ uint64_t FiberFuture::waitForMultiple(FiberFuture ** futureArray, uint64_t futur
     if (multipleWaitCount == futureArraySize)
     {
         // all attached; block until first signals
-        completionFuture.wait();
+        completionFuture.wait(waitCycles);
     }
 
     //
@@ -257,13 +257,13 @@ bool FiberFuture::detachWaiter(MultipleWaitState * waitState) noexcept
     }
 }
 
-int FiberFuture::waitWithTimeout(FiberFuture * future, uint64_t nanoseconds) noexcept
+int FiberFuture::waitWithTimeout(FiberFuture * future, uint64_t nanoseconds, uint64_t * waitCycles) noexcept
 {
     FiberScheduler::SleepFuture sleepFuture;
     FiberScheduler::sleep(nanoseconds, &sleepFuture);
 
     FiberFuture * futureArray[] = {future, &sleepFuture};
-    waitForMultiple(futureArray, std::size(futureArray));
+    waitForMultiple(futureArray, std::size(futureArray), waitCycles);
 
     int r;
     if (future->isSet(&r))
@@ -278,7 +278,7 @@ int FiberFuture::waitWithTimeout(FiberFuture * future, uint64_t nanoseconds) noe
     // Must wait before returning: the sleep tree holds a raw pointer to sleepFuture,
     // and cancelQueue may also reference it. Returning before the sleep is fully
     // resolved would free the stack-allocated future while it is still reachable.
-    sleepFuture.wait();
+    sleepFuture.wait(waitCycles);
     return r;
 }
 


### PR DESCRIPTION
Both take a trailing optional accumulator and thread it through every internal suspension - the single-future fast path, the completion wait, and waitWithTimeout's sleep drain - matching FiberFuture::wait.