### PR TITLE
Install gdb in runner images

### DIFF
--- a/ci/infrastructure/projects.py
+++ b/ci/infrastructure/projects.py
@@ -49,7 +49,7 @@ def _silk_ci_dependencies_component():
             (
                 "DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 "
                 "install -y clang-21 clang-format-21 llvm-21 cmake "
-                "libstdc++-13-dev ninja-build ccache libboost-dev "
+                "libstdc++-13-dev ninja-build ccache gdb libboost-dev "
                 "libdouble-conversion-dev libelf-dev zlib1g-dev"
             ),
         ],
@@ -68,13 +68,15 @@ def _silk_ci_image_test_component():
             "test -x /usr/bin/cmake",
             "test -x /usr/bin/ninja",
             "test -x /usr/bin/ccache",
+            "test -x /usr/bin/gdb",
             "clang-21 --version",
             "clang-format-21 --version",
             "cmake --version",
             "ninja --version",
             "ccache --version",
+            "gdb --version",
             (
-                "for package in llvm-21 libstdc++-13-dev libboost-dev "
+                "for package in llvm-21 libstdc++-13-dev gdb libboost-dev "
                 "libdouble-conversion-dev libelf-dev zlib1g-dev; do "
                 "dpkg-query -W -f='${Status}\\n' \"$package\" "
                 "| grep -qx 'install ok installed'; done"
@@ -149,7 +151,7 @@ def _praktika_launch_user_data():
 
 
 def _image_builders():
-    image_recipe_version = "1.0.9"
+    image_recipe_version = "1.0.10"
     prebuilt_venvs = [
         ImageBuilder.PrebuiltVenv(
             name=PRAKTIKA_BASE_VENV,


### PR DESCRIPTION
## Summary
- Install `gdb` in the Silk CI runner image dependency component.
- Validate `gdb` in the image test component.
- Bump the shared Image Builder recipe/component version to `1.0.10`.

## Image update instructions
1. Install Praktika from `_PRAKTIKA_WHL`:
   `python3 -m pip install --user --break-system-packages --force-reinstall https://praktika-artifacts-eu-north-1.s3.amazonaws.com/packages/0.1/praktika-0.0.0-py3-none-any.whl`
2. Update Image Builder dependencies in `ci/infrastructure/projects.py`.
3. Bump `image_recipe_version` so Image Builder creates a new component/recipe version.
4. Deploy Image Builder:
   `python3 -m praktika infrastructure --deploy --only ImageBuilder`
5. Wait until the new images are ready in AWS Image Builder, then deploy launch templates/ASGs:
   `python3 -m praktika infrastructure --deploy --only LaunchTemplate AutoScalingGroup`
