### PR TITLE
Add mmap accounting hooks

### DIFF
--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <cerrno>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -42,6 +43,11 @@ using FiberParametersDtor = void(void * parameters) noexcept;
  * Fiber switch callback.  Called when fiber suspended/resumed.
  */
 using FiberSwitchCallback = void(Fiber * fiber) noexcept;
+
+/**
+ * Memory mapping callback.  Called when silk maps or unmaps memory outside the C++ heap.
+ */
+using MemoryMapCallback = void(void * ptr, size_t size) noexcept;
 
 /**
  * Packed fiber identity: [category:8 | cpu:10 | counter:46] stored as uint64_t.
@@ -165,6 +171,11 @@ public:
         // across the OS thread the fiber borrows. Not invoked for proxy fibers.
         FiberSwitchCallback * fiberSuspend = nullptr;
         FiberSwitchCallback * fiberResume = nullptr;
+
+        // Optional hooks for silk memory maps/unmaps outside the heap: fiber stacks (guard pages
+        // excluded) and io_uring rings.
+        MemoryMapCallback * accountMemoryMapped = nullptr;
+        MemoryMapCallback * accountMemoryUnmapped = nullptr;
     };
 
     /**

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -312,6 +312,12 @@ Fiber::~Fiber() noexcept
     {
         int r = ::munmap(stack, FiberScheduler::getOptions().fiberStackSize + 2 * kPageSize);
         SILK_ASSERT(!r);
+
+        if (FiberScheduler::getOptions().accountMemoryUnmapped)
+        {
+            FiberScheduler::getOptions().accountMemoryUnmapped(
+                static_cast<uint8_t *>(stack) + kPageSize, FiberScheduler::getOptions().fiberStackSize);
+        }
     }
 }
 
@@ -347,6 +353,11 @@ bool Fiber::initialize(
 
         r = ::mprotect(static_cast<uint8_t *>(stack) + kPageSize + fiberStackSize, kPageSize, PROT_NONE);
         SILK_ASSERT(!r);
+
+        if (FiberScheduler::getOptions().accountMemoryMapped)
+        {
+            FiberScheduler::getOptions().accountMemoryMapped(static_cast<uint8_t *>(stack) + kPageSize, fiberStackSize);
+        }
     }
 
 #if defined(__SANITIZE_ADDRESS__)
@@ -691,6 +702,23 @@ struct FiberScheduler::ProcessorState
     BoundedQueue<Fiber *> readyQueue;
 };
 
+static void accountRingMemoryMappings(const io_uring & ring, MemoryMapCallback * callback) noexcept
+{
+    if (!callback)
+    {
+        return;
+    }
+
+    callback(ring.sq.sqes, ring.sq.sqes_sz);
+    callback(ring.sq.ring_ptr, ring.sq.ring_sz);
+
+    // The kernel serves both rings from one mapping given IORING_FEAT_SINGLE_MMAP.
+    if (ring.cq.ring_ptr != ring.sq.ring_ptr)
+    {
+        callback(ring.cq.ring_ptr, ring.cq.ring_sz);
+    }
+}
+
 void FiberScheduler::ProcessorState::initialize(uint16_t cpu) noexcept
 {
     SILK_ASSERT(cpu < kInvalidProcessorNumber);
@@ -712,6 +740,8 @@ void FiberScheduler::ProcessorState::initialize(uint16_t cpu) noexcept
     // postWakeup posts cross-ring doorbells with IOSQE_CQE_SKIP_SUCCESS to drop the send-side completion.
     SILK_ASSERT(params.features & IORING_FEAT_CQE_SKIP);
 
+    accountRingMemoryMappings(ring, options.accountMemoryMapped);
+
     // Arm the wakeup doorbell. The kernel can end the multishot poll on CQ overflow,
     // so handleCompletionQueueSlow re-arms it through the same path on F_MORE loss.
     enqueueDoorbell();
@@ -729,6 +759,7 @@ void FiberScheduler::ProcessorState::destroy() noexcept
 {
     if (eventFd >= 0)
     {
+        accountRingMemoryMappings(ring, options.accountMemoryUnmapped);
         ::io_uring_queue_exit(&ring);
         ::close(eventFd);
     }


### PR DESCRIPTION
Integration with ClickHouse requires accounting for memory allocations via mmap (as opposed to allocations served by `new`/`delete`): fiber stacks (excluding guard pages) and io_uring buffers.

This is how the hooks will be used: https://github.com/ClickHouse/ClickHouse/pull/111275/changes/24fae1abd5a6ea5812b755218f30f4b4b5e1caf6.