### PR TITLE
Force migrate fibers under sanitizers

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1521,6 +1521,15 @@ FiberScheduler::ProcessorState * FiberScheduler::enqueueReady(ProcessorState * p
             {
                 fiber->processorNumber = processor->number;
             }
+#if !defined(NDEBUG) || defined(__SANITIZE_THREAD__)
+            else if (scheduler->schedulerThreadCount > 1)
+            {
+                do
+                {
+                    fiber->processorNumber = (fiber->processorNumber + 1) % scheduler->processorCount;
+                } while (!CPU_ISSET(fiber->processorNumber, &scheduler->activeMask));
+            }
+#endif
 
             ProcessorState * target = &scheduler->processorState[fiber->processorNumber];
             if (target->readyQueue.enqueue(fiber))


### PR DESCRIPTION
This code has a somewhat subtle bug:
```
std::mutex m;

void foo(std::mutex & m)
{
    m.lock();
    /// some code
    silk::FiberScheduler::yield(); /// with work stealing, migrates the fiber to another worker thread
    /// some code
    m.unlock() /// UB
}
```

And it may never trigger CI failures (even under sanitizers) - unless we hit work stealing. And to hit work stealing, the tests need to run the buggy code many times, which is not always the case for many tests (and legitimately so).

So I suggest we force-migrate fibers to the `(fiber->processorNumber + 1) % scheduler->processorCount` processor (if it's CPU is "active") in `enqueueReady` in sanitizer builds.

There's still a chance we force-migrate from processor X to processor Y - only for the fiber to get stolen by processor X. But I think it's acceptable to have a residual false negative rate. This is exactly why I'm not covering this forced migration with a test.
