### PR TITLE
pageSize should be retrieved via ::sysconf(_SC_PAGESIZE), not compiled into the binary

### DIFF
--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -39,12 +39,18 @@ extern "C" ptrdiff_t rseq_offset;
 namespace silk
 {
 
-/** System page size in bytes. */
+/** Retrieves system page size in bytes. */
+static inline uint64_t getPageSize() noexcept
+{
 #if defined(PAGE_SIZE)
-static constexpr uint64_t kPageSize = PAGE_SIZE;
+    return PAGE_SIZE;
 #else
-static constexpr uint64_t kPageSize = 4096;
+    // We don't need to cache the value - this call doesn't result in a syscall
+    // and just fetches a value from memory which is supposed to be initialized
+    // by glibc.
+    return ::sysconf(_SC_PAGESIZE);
 #endif
+}
 
 /** Cache line size in bytes. */
 #if defined(CACHE_LINESIZE)

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -310,13 +310,13 @@ Fiber::~Fiber() noexcept
 
     if (stack)
     {
-        int r = ::munmap(stack, FiberScheduler::getOptions().fiberStackSize + 2 * kPageSize);
+        int r = ::munmap(stack, FiberScheduler::getOptions().fiberStackSize + 2 * getPageSize());
         SILK_ASSERT(!r);
 
         if (FiberScheduler::getOptions().accountMemoryUnmapped)
         {
             FiberScheduler::getOptions().accountMemoryUnmapped(
-                static_cast<uint8_t *>(stack) + kPageSize, FiberScheduler::getOptions().fiberStackSize);
+                static_cast<uint8_t *>(stack) + getPageSize(), FiberScheduler::getOptions().fiberStackSize);
         }
     }
 }
@@ -341,22 +341,22 @@ bool Fiber::initialize(
 
     if (!stack)
     {
-        stack = ::mmap(nullptr, fiberStackSize + 2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        stack = ::mmap(nullptr, fiberStackSize + 2 * getPageSize(), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (stack == MAP_FAILED) [[unlikely]]
         {
             stack = nullptr;
             return false;
         }
 
-        int r = ::mprotect(stack, kPageSize, PROT_NONE);
+        int r = ::mprotect(stack, getPageSize(), PROT_NONE);
         SILK_ASSERT(!r);
 
-        r = ::mprotect(static_cast<uint8_t *>(stack) + kPageSize + fiberStackSize, kPageSize, PROT_NONE);
+        r = ::mprotect(static_cast<uint8_t *>(stack) + getPageSize() + fiberStackSize, getPageSize(), PROT_NONE);
         SILK_ASSERT(!r);
 
         if (FiberScheduler::getOptions().accountMemoryMapped)
         {
-            FiberScheduler::getOptions().accountMemoryMapped(static_cast<uint8_t *>(stack) + kPageSize, fiberStackSize);
+            FiberScheduler::getOptions().accountMemoryMapped(static_cast<uint8_t *>(stack) + getPageSize(), fiberStackSize);
         }
     }
 
@@ -372,7 +372,7 @@ bool Fiber::initialize(
 
     fiberMain = fiberMain_;
     parametersDtor = parametersDtor_;
-    fiberContext = make_fcontext(static_cast<uint8_t *>(stack) + kPageSize + fiberStackSize, fiberStackSize, fiberContextMain);
+    fiberContext = make_fcontext(static_cast<uint8_t *>(stack) + getPageSize() + fiberStackSize, fiberStackSize, fiberContextMain);
 
     return true;
 }
@@ -397,7 +397,7 @@ void Fiber::switchToFiberContext() noexcept
 #if defined(__SANITIZE_ADDRESS__)
     void * schedulerFakeStack = nullptr;
     __sanitizer_start_switch_fiber(
-        &schedulerFakeStack, static_cast<uint8_t *>(stack) + kPageSize, FiberScheduler::getOptions().fiberStackSize);
+        &schedulerFakeStack, static_cast<uint8_t *>(stack) + getPageSize(), FiberScheduler::getOptions().fiberStackSize);
 #endif
 
 #if defined(__SANITIZE_THREAD__)
@@ -1187,7 +1187,7 @@ void FiberScheduler::initialize(const Options * userOptions) noexcept
         options = *userOptions;
     }
 
-    SILK_ASSERT(options.fiberStackSize >= kPageSize && (options.fiberStackSize % kPageSize) == 0);
+    SILK_ASSERT(options.fiberStackSize >= getPageSize() && (options.fiberStackSize % getPageSize()) == 0);
     SILK_ASSERT(options.readyQueueCapacity >= 2 && (options.readyQueueCapacity & (options.readyQueueCapacity - 1)) == 0);
     SILK_ASSERT(options.readyDispatchBatch >= 1);
     SILK_ASSERT(options.ioUringQueueSize >= 2 && (options.ioUringQueueSize & (options.ioUringQueueSize - 1)) == 0);

--- a/src/util/memory-pool.cpp
+++ b/src/util/memory-pool.cpp
@@ -12,7 +12,7 @@ MemoryPoolBase::MemoryPoolBase(
     uint32_t objectSize, uint32_t alignment, uint32_t stackEntryOffset, InitFn * initialize, DestroyFn * destroy) noexcept
     : objectSize(alignUp(objectSize, alignment))
     , alignment(alignment)
-    , chunkSize(alignUp<uint32_t>(slotsOffset() + MIN_BATCH_SIZE * this->objectSize, kPageSize))
+    , chunkSize(alignUp<uint32_t>(slotsOffset() + MIN_BATCH_SIZE * this->objectSize, static_cast<uint32_t>(getPageSize())))
     , stackEntryOffset(stackEntryOffset)
     , initialize(initialize)
     , destroy(destroy)


### PR DESCRIPTION
To be able to compile once and run anywhere. Real usecase - NVidia Grace CPU-based platforms (aarch64) following NVidia guidelines (64KiB page size).