### PR TITLE
Add FiberScheduler::splice

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -136,6 +136,10 @@ Each of `read`, `write`, and `poll` has two overloads: a blocking form that subm
 
 The underlying liburing helpers are `io_uring_register_buffers`, `io_uring_prep_read_fixed`, and `io_uring_prep_write_fixed`. `file-perf --fixed-buffers` exercises this path (see `docs/perf.md`).
 
+### Splice
+
+`splice` submits `IORING_OP_SPLICE` in the same blocking and async forms as `read` and `write`, and moves bytes between two descriptors entirely inside the kernel. As with `splice(2)` at least one of the two descriptors must be a pipe, and the offsets apply only to seekable files, so a caller relaying a stream between two sockets moves the bytes through an intermediate pipe: one splice from the source socket into the pipe, another from the pipe into the destination socket. Nothing is copied into user space, so the throughput of such a relay does not depend on any user-space buffer size; `bytesSpliced` of zero means the source reached end of input.
+
 ---
 
 ## Sleep Cancellation

--- a/include/silk/fibers/fiber.h
+++ b/include/silk/fibers/fiber.h
@@ -585,6 +585,44 @@ public:
     static void accept(int fd, sockaddr * addr, socklen_t * addrlen, int flags, uint64_t * acceptedFd, IoFuture * future) noexcept;
 
     /**
+     * Blocking splice: move up to @p len bytes from @p fdIn to @p fdOut without copying
+     * through user space. As with splice(2), at least one descriptor must refer to a pipe.
+     * Offsets apply to seekable files; pass -1 for a pipe or a socket.
+     *
+     * @param fdIn         Source descriptor.
+     * @param offsetIn     Byte offset within @p fdIn, or -1 for a pipe or a socket.
+     * @param fdOut        Destination descriptor.
+     * @param offsetOut    Byte offset within @p fdOut, or -1 for a pipe or a socket.
+     * @param len          Maximum number of bytes to move.
+     * @param flags        splice(2) flags (e.g. SPLICE_F_MOVE, SPLICE_F_MORE).
+     * @param bytesSpliced If not null, receives the number of bytes moved (0 means end of input).
+     * @return             0 on success, or a errno on failure.
+     */
+    static int splice(
+        int fdIn, int64_t offsetIn, int fdOut, int64_t offsetOut, uint64_t len, uint32_t flags, uint64_t * bytesSpliced = nullptr) noexcept
+    {
+        IoFuture future;
+        splice(fdIn, offsetIn, fdOut, offsetOut, len, flags, bytesSpliced, &future);
+        return future.wait();
+    }
+
+    /**
+     * Async splice. Returns immediately; the caller must wait on @p future for the result.
+     * See the blocking overload for the parameter meanings.
+     *
+     * @param future Completion handle; wait() returns 0 on success or a errno on failure.
+     */
+    static void splice(
+        int fdIn,
+        int64_t offsetIn,
+        int fdOut,
+        int64_t offsetOut,
+        uint64_t len,
+        uint32_t flags,
+        uint64_t * bytesSpliced,
+        IoFuture * future) noexcept;
+
+    /**
      * Completion handle for an async sleep submitted via sleep().
      */
     class SleepFuture : public FiberFuture

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -1812,6 +1812,23 @@ void FiberScheduler::accept(int fd, sockaddr * addr, socklen_t * addrlen, int fl
     enqueueIo(future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_accept(sqe, fd, addr, addrlen, flags); });
 }
 
+void FiberScheduler::splice(
+    int fdIn,
+    int64_t offsetIn,
+    int fdOut,
+    int64_t offsetOut,
+    uint64_t len,
+    uint32_t flags,
+    uint64_t * bytesSpliced,
+    IoFuture * future) noexcept
+{
+    future->result = bytesSpliced;
+    enqueueIo(
+        future,
+        [=](io_uring_sqe * sqe) noexcept
+        { ::io_uring_prep_splice(sqe, fdIn, offsetIn, fdOut, offsetOut, static_cast<unsigned int>(len), flags); });
+}
+
 void FiberScheduler::cancelIo(IoFuture * future) noexcept
 {
     // The cancel SQE must go to the SAME io_uring ring that holds the original

--- a/src/fibers/tests/fiber-io-test.cpp
+++ b/src/fibers/tests/fiber-io-test.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 
+#include <fcntl.h>
 #include <poll.h>
 #include <unistd.h>
 
@@ -670,6 +671,78 @@ TEST(FiberIo, fixedWriteReadRoundTrip)
 
     std::free(buf);
     ::close(fd);
+}
+
+// splice: relay a stream from one socket to another through a pipe, the pattern
+// a proxy uses to forward traffic without copying it through user space. The
+// first leg goes through the blocking overload and the second through the async
+// one; a last splice on a source whose peer is gone reports end of input as
+// zero bytes moved.
+TEST(FiberIo, spliceThroughPipe)
+{
+    static constexpr char MESSAGE[] = "splice";
+
+    int source[2];
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, source), 0);
+
+    int destination[2];
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, destination), 0);
+
+    int pipeFds[2];
+    ASSERT_EQ(::pipe(pipeFds), 0);
+
+    ssize_t written = ::write(source[1], MESSAGE, sizeof(MESSAGE));
+    ASSERT_EQ(written, static_cast<ssize_t>(sizeof(MESSAGE)));
+
+    // Shut the write side so the source reports end of input once the payload is consumed.
+    int r = ::shutdown(source[1], SHUT_WR);
+    ASSERT_EQ(r, 0);
+
+    struct Params
+    {
+        int sourceFd;
+        int pipeReadFd;
+        int pipeWriteFd;
+        int destinationFd;
+
+        static int fiberMain(Params * params) noexcept
+        {
+            uint64_t bytesIntoPipe = 0;
+            int r = FiberScheduler::splice(params->sourceFd, -1, params->pipeWriteFd, -1, sizeof(MESSAGE), SPLICE_F_MOVE, &bytesIntoPipe);
+            EXPECT_EQ(r, 0);
+            EXPECT_EQ(bytesIntoPipe, sizeof(MESSAGE));
+
+            uint64_t bytesOutOfPipe = 0;
+            FiberScheduler::IoFuture future;
+            FiberScheduler::splice(
+                params->pipeReadFd, -1, params->destinationFd, -1, bytesIntoPipe, SPLICE_F_MOVE, &bytesOutOfPipe, &future);
+            EXPECT_EQ(future.wait(), 0);
+            EXPECT_EQ(bytesOutOfPipe, sizeof(MESSAGE));
+
+            uint64_t bytesAfterEndOfInput = 0;
+            r = FiberScheduler::splice(
+                params->sourceFd, -1, params->pipeWriteFd, -1, sizeof(MESSAGE), SPLICE_F_MOVE, &bytesAfterEndOfInput);
+            EXPECT_EQ(r, 0);
+            EXPECT_EQ(bytesAfterEndOfInput, 0u);
+
+            return 0;
+        }
+    };
+
+    r = FiberScheduler::run(Params::fiberMain, Params{source[0], pipeFds[0], pipeFds[1], destination[1]});
+    ASSERT_EQ(r, 0);
+
+    char buf[sizeof(MESSAGE)] = {};
+    ssize_t bytesRead = ::read(destination[0], buf, sizeof(buf));
+    ASSERT_EQ(bytesRead, static_cast<ssize_t>(sizeof(MESSAGE)));
+    ASSERT_STREQ(buf, MESSAGE);
+
+    ::close(source[0]);
+    ::close(source[1]);
+    ::close(destination[0]);
+    ::close(destination[1]);
+    ::close(pipeFds[0]);
+    ::close(pipeFds[1]);
 }
 
 } // namespace silk


### PR DESCRIPTION
`FiberScheduler::splice` submits `IORING_OP_SPLICE` in the same blocking and async forms as `read`, `write` and `accept`, so a fiber can move bytes between two descriptors entirely inside the kernel. As with `splice(2)` one of the two descriptors must be a pipe, which means a relay between two sockets goes socket -> pipe -> socket and never copies the payload into user space.

This is what the ClickHouse proxy uses to forward plaintext connections: https://github.com/ClickHouse/ClickHouse/pull/110105. With the copy relay the bulk HTTP throughput of the proxy was bounded by the user-space buffer size (845 MB/s at a 16 KiB buffer); after switching those legs to `splice` it reaches ~5 GB/s, matching a direct connection to the backend, and the added per-query latency is unchanged. TLS-terminating legs keep the copy path since their bytes have to be decrypted in user space.

The test relays a payload from one socket to another through a pipe, over the blocking overload for the first leg and the async one for the second, and checks that a source whose peer has shut down reports end of input as zero bytes moved. `./bb test -R FiberIo` passes locally in the debug build and under all four sanitizers (address, memory, thread, undefined).

The change is currently carried on the `add-splice-op` branch, which the ClickHouse pull request pins; once this is merged and `clickhouse-public` is rebuilt, that pull request will re-pin the submodule to the generated commit.