### PR TITLE
Park processors with `IORING_ENTER_NO_IOWAIT`

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -695,6 +695,9 @@ struct FiberScheduler::ProcessorState
     // service-loop iteration.
     io_uring ring{};
 
+    // Flags for the idle park's io_uring_enter2.
+    uint32_t parkEnterFlags;
+
     // Per-CPU bounded MPMC queue of ready fibers.  Spans 3 cache lines and
     // is hammered from neighboring CPUs during steal, so left at the end of
     // ProcessorState to keep its cache-line traffic away from the per-CPU
@@ -739,6 +742,13 @@ void FiberScheduler::ProcessorState::initialize(uint16_t cpu) noexcept
 
     // postWakeup posts cross-ring doorbells with IOSQE_CQE_SKIP_SUCCESS to drop the send-side completion.
     SILK_ASSERT(params.features & IORING_FEAT_CQE_SKIP);
+
+    // Without IORING_FEAT_NO_IOWAIT, the kernel may account parked threads as iowait CPU usage.
+    parkEnterFlags = IORING_ENTER_GETEVENTS | IORING_ENTER_EXT_ARG;
+    if (params.features & IORING_FEAT_NO_IOWAIT)
+    {
+        parkEnterFlags |= IORING_ENTER_NO_IOWAIT;
+    }
 
     accountRingMemoryMappings(ring, options.accountMemoryMapped);
 
@@ -836,7 +846,7 @@ void FiberScheduler::ProcessorState::parkThread(uint64_t waitNs, CpuTimer * time
 
         timer->reset(simpleCounters[SCHEDULER_IDLE_TIME], number);
 
-        int r = ::io_uring_enter2(ring.ring_fd, 0, 1, IORING_ENTER_GETEVENTS | IORING_ENTER_EXT_ARG, &arg, sizeof(arg));
+        int r = ::io_uring_enter2(ring.ring_fd, 0, 1, parkEnterFlags, &arg, sizeof(arg));
         if (r < 0)
         {
             // io_uring_enter2 returns -errno directly; it does not set errno.


### PR DESCRIPTION
Without `IORING_ENTER_NO_IOWAIT`, the kernel accounts a processor thread parked in `io_uring_enter2` as iowait (rather than idle) as long as the CPU core the thread ran on is not occupied by other runnable threads. So with the Silk runtime enabled, an otherwise idle system becomes iowait-heavy in `/proc/stat` (and therefore in all the commands like `htop`, `atop`).

In ClickHouse, [it breaks the CI](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=112667&sha=7c2b246ff55243fcc25f15d191b85a7ae5406232&name_0=PR&name_1=Stateless+tests+%28amd_debug%2C+parallel%29&name_2=Tests), which can be fixed on the ClickHouse side, but, arguably, it's still worth improving CPU accounting on the Silk side. 

The feature was added in the 6.15 kernel version, so we don't expect the feature to exist.