### PR TITLE
Avoid truncating oversized splice lengths

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -22,7 +22,6 @@
 #include <atomic>
 #include <cerrno>
 #include <cstdint>
-#include <limits>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -1593,9 +1592,9 @@ void FiberScheduler::splice(
     IoFuture * future) noexcept
 {
     future->result = bytesSpliced;
-    const uint32_t spliceLen = static_cast<uint32_t>(std::min<uint64_t>(len, std::numeric_limits<uint32_t>::max()));
+    uint32_t boundedLen = static_cast<uint32_t>(std::min<uint64_t>(len, UINT32_MAX));
     enqueueIo(
-        future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_splice(sqe, fdIn, offsetIn, fdOut, offsetOut, spliceLen, flags); });
+        future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_splice(sqe, fdIn, offsetIn, fdOut, offsetOut, boundedLen, flags); });
 }
 
 void FiberScheduler::cancelIo(IoFuture * future) noexcept

--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -22,6 +22,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -1833,10 +1834,9 @@ void FiberScheduler::splice(
     IoFuture * future) noexcept
 {
     future->result = bytesSpliced;
+    const uint32_t spliceLen = static_cast<uint32_t>(std::min<uint64_t>(len, std::numeric_limits<uint32_t>::max()));
     enqueueIo(
-        future,
-        [=](io_uring_sqe * sqe) noexcept
-        { ::io_uring_prep_splice(sqe, fdIn, offsetIn, fdOut, offsetOut, static_cast<unsigned int>(len), flags); });
+        future, [=](io_uring_sqe * sqe) noexcept { ::io_uring_prep_splice(sqe, fdIn, offsetIn, fdOut, offsetOut, spliceLen, flags); });
 }
 
 void FiberScheduler::cancelIo(IoFuture * future) noexcept

--- a/src/fibers/tests/fiber-io-test.cpp
+++ b/src/fibers/tests/fiber-io-test.cpp
@@ -750,14 +750,18 @@ TEST(FiberIo, spliceLargeLength)
     static constexpr char MESSAGE[] = "splice";
 
     int source[2];
-    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, source), 0);
+    int r = ::socketpair(AF_UNIX, SOCK_STREAM, 0, source);
+    ASSERT_EQ(r, 0);
 
     int pipeFds[2];
-    ASSERT_EQ(::pipe(pipeFds), 0);
+    r = ::pipe(pipeFds);
+    ASSERT_EQ(r, 0);
 
     ssize_t written = ::write(source[1], MESSAGE, sizeof(MESSAGE));
     ASSERT_EQ(written, static_cast<ssize_t>(sizeof(MESSAGE)));
-    ASSERT_EQ(::shutdown(source[1], SHUT_WR), 0);
+
+    r = ::shutdown(source[1], SHUT_WR);
+    ASSERT_EQ(r, 0);
 
     struct Params
     {
@@ -773,8 +777,9 @@ TEST(FiberIo, spliceLargeLength)
     };
 
     uint64_t bytesSpliced = 0;
-    ASSERT_EQ(FiberScheduler::run(Params::fiberMain, Params{source[0], pipeFds[1], &bytesSpliced}), 0);
-    EXPECT_EQ(bytesSpliced, sizeof(MESSAGE));
+    r = FiberScheduler::run(Params::fiberMain, Params{source[0], pipeFds[1], &bytesSpliced});
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(bytesSpliced, sizeof(MESSAGE));
 
     ::close(source[0]);
     ::close(source[1]);

--- a/src/fibers/tests/fiber-io-test.cpp
+++ b/src/fibers/tests/fiber-io-test.cpp
@@ -745,4 +745,41 @@ TEST(FiberIo, spliceThroughPipe)
     ::close(pipeFds[1]);
 }
 
+TEST(FiberIo, spliceLargeLength)
+{
+    static constexpr char MESSAGE[] = "splice";
+
+    int source[2];
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, source), 0);
+
+    int pipeFds[2];
+    ASSERT_EQ(::pipe(pipeFds), 0);
+
+    ssize_t written = ::write(source[1], MESSAGE, sizeof(MESSAGE));
+    ASSERT_EQ(written, static_cast<ssize_t>(sizeof(MESSAGE)));
+    ASSERT_EQ(::shutdown(source[1], SHUT_WR), 0);
+
+    struct Params
+    {
+        int sourceFd;
+        int pipeWriteFd;
+        uint64_t * bytesSpliced;
+
+        static int fiberMain(Params * params) noexcept
+        {
+            return FiberScheduler::splice(
+                params->sourceFd, -1, params->pipeWriteFd, -1, uint64_t{1} << 32, SPLICE_F_MOVE, params->bytesSpliced);
+        }
+    };
+
+    uint64_t bytesSpliced = 0;
+    ASSERT_EQ(FiberScheduler::run(Params::fiberMain, Params{source[0], pipeFds[1], &bytesSpliced}), 0);
+    EXPECT_EQ(bytesSpliced, sizeof(MESSAGE));
+
+    ::close(source[0]);
+    ::close(source[1]);
+    ::close(pipeFds[0]);
+    ::close(pipeFds[1]);
+}
+
 } // namespace silk


### PR DESCRIPTION
## What changed

- Keep the public `FiberScheduler::splice` length API unchanged.
- Bound the requested length before passing it to the io_uring 32-bit field.
- Add a regression test with a tiny payload and a `1ULL << 32` request.

## Why this matters

`FiberScheduler::splice` accepts a `uint64_t` length, but `io_uring_prep_splice` stores the length in a 32-bit field.

Before this change, a request of exactly 4 GiB was narrowed to `0`. The kernel treated that as a zero-length splice, so the caller received a successful result with `0` bytes instead of the available data. That can look like EOF and silently skip work.

The fix saturates oversized values at the largest length io_uring can represent, so they no longer wrap around to a smaller or zero request. The public API stays unchanged.

## Tests

- `./bb fmt --check`
- `ctest --preset debug --parallel 1 --tests-regex FiberIo --timeout 180` (14/14 passed)