### PR TITLE
Avoid overflow in TSC time conversions

### DIFF
--- a/include/silk/util/tsc.h
+++ b/include/silk/util/tsc.h
@@ -10,6 +10,9 @@ namespace silk
  *
  * Frequency is queried once via CPUID at initialization and cached.
  * Conversions use fixed-point multiply+shift - no division on the hot path.
+ * Conversion results are represented as uint64_t. Callers must keep inputs
+ * within the range where the converted value, and any subsequent deadline
+ * arithmetic, fit in uint64_t; values beyond that range are not saturated.
  */
 class Tsc
 {
@@ -48,10 +51,24 @@ public:
     static uint64_t getFrequency() noexcept { return frequency; }
 
     /** Convert TSC cycles to nanoseconds. */
-    static uint64_t cyclesToNanoseconds(uint64_t cycles) noexcept { return (cycles * nsPerCycleFp) >> SHIFT; }
+    static uint64_t cyclesToNanoseconds(uint64_t cycles) noexcept
+    {
+        if (cycles > maxCyclesBeforeMultiplyOverflow) [[unlikely]]
+        {
+            return static_cast<uint64_t>((static_cast<unsigned __int128>(cycles) * nsPerCycleFp) >> SHIFT);
+        }
+        return (cycles * nsPerCycleFp) >> SHIFT;
+    }
 
     /** Convert nanoseconds to TSC cycles. */
-    static uint64_t nanosecondsToCycles(uint64_t ns) noexcept { return (ns * cyclesPerNsFp) >> SHIFT; }
+    static uint64_t nanosecondsToCycles(uint64_t ns) noexcept
+    {
+        if (ns > maxNanosecondsBeforeMultiplyOverflow) [[unlikely]]
+        {
+            return static_cast<uint64_t>((static_cast<unsigned __int128>(ns) * cyclesPerNsFp) >> SHIFT);
+        }
+        return (ns * cyclesPerNsFp) >> SHIFT;
+    }
 
 private:
     static constexpr uint32_t SHIFT = 20;
@@ -59,6 +76,8 @@ private:
     inline static uint64_t frequency = 0; ///< Hz
     inline static uint64_t nsPerCycleFp = 0; ///< (1 << SHIFT) * 1'000'000'000 / frequency
     inline static uint64_t cyclesPerNsFp = 0; ///< frequency * (1 << SHIFT) / 1'000'000'000
+    inline static uint64_t maxCyclesBeforeMultiplyOverflow = 0;
+    inline static uint64_t maxNanosecondsBeforeMultiplyOverflow = 0;
 };
 
 } // namespace silk

--- a/src/util/benchmarks/tsc-bench.cpp
+++ b/src/util/benchmarks/tsc-bench.cpp
@@ -27,6 +27,23 @@ BENCHMARK_F(TscBench, GetNanoseconds)(benchmark::State & state)
     }
 }
 
+BENCHMARK_F(TscBench, CyclesToNanosecondsShort)(benchmark::State & state)
+{
+    const uint64_t cycles = Tsc::nanosecondsToCycles(1'000'000);
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(Tsc::cyclesToNanoseconds(cycles));
+    }
+}
+
+BENCHMARK_F(TscBench, NanosecondsToCyclesShort)(benchmark::State & state)
+{
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(Tsc::nanosecondsToCycles(1'000'000));
+    }
+}
+
 BENCHMARK_F(TscBench, GetTimeNanoseconds)(benchmark::State & state)
 {
     for (auto _ : state)

--- a/src/util/tests/tsc-test.cpp
+++ b/src/util/tests/tsc-test.cpp
@@ -48,6 +48,56 @@ TEST(Tsc, CyclesToNanosecondsRoundTrip)
     EXPECT_NEAR(static_cast<double>(result), static_cast<double>(ns), ns * 0.002);
 }
 
+TEST(Tsc, LongConversionsDoNotOverflow)
+{
+    constexpr uint64_t SHIFT = 20;
+    constexpr uint64_t NS_PER_SECOND = 1'000'000'000;
+    constexpr uint64_t ns = 365ULL * 24 * 60 * 60 * NS_PER_SECOND;
+
+    const uint64_t frequency = Tsc::getFrequency();
+    const uint64_t cyclesPerNsFp = frequency * (1ULL << SHIFT) / NS_PER_SECOND;
+    const uint64_t nsPerCycleFp = (1ULL << SHIFT) * NS_PER_SECOND / frequency;
+    ASSERT_GT(cyclesPerNsFp, 0);
+    ASSERT_GT(nsPerCycleFp, 0);
+
+    const uint64_t cycles = static_cast<uint64_t>((static_cast<unsigned __int128>(ns) * frequency) / NS_PER_SECOND);
+    ASSERT_GT(ns, UINT64_MAX / cyclesPerNsFp);
+    ASSERT_GT(cycles, UINT64_MAX / nsPerCycleFp);
+
+    const uint64_t expectedCycles = static_cast<uint64_t>((static_cast<unsigned __int128>(ns) * cyclesPerNsFp) >> SHIFT);
+    EXPECT_EQ(Tsc::nanosecondsToCycles(ns), expectedCycles);
+
+    const uint64_t expectedNanoseconds = static_cast<uint64_t>((static_cast<unsigned __int128>(cycles) * nsPerCycleFp) >> SHIFT);
+    EXPECT_EQ(Tsc::cyclesToNanoseconds(cycles), expectedNanoseconds);
+}
+
+TEST(Tsc, ConversionOverflowThresholds)
+{
+    constexpr uint64_t SHIFT = 20;
+    constexpr uint64_t NS_PER_SECOND = 1'000'000'000;
+
+    const uint64_t frequency = Tsc::getFrequency();
+    const uint64_t cyclesPerNsFp = frequency * (1ULL << SHIFT) / NS_PER_SECOND;
+    const uint64_t nsPerCycleFp = (1ULL << SHIFT) * NS_PER_SECOND / frequency;
+    ASSERT_GT(cyclesPerNsFp, 0);
+    ASSERT_GT(nsPerCycleFp, 0);
+
+    const uint64_t maxCyclesBeforeMultiplyOverflow = UINT64_MAX / nsPerCycleFp;
+    const uint64_t maxNanosecondsBeforeMultiplyOverflow = UINT64_MAX / cyclesPerNsFp;
+    ASSERT_LT(maxCyclesBeforeMultiplyOverflow, UINT64_MAX);
+    ASSERT_LT(maxNanosecondsBeforeMultiplyOverflow, UINT64_MAX);
+
+    const auto expectedNanoseconds = [nsPerCycleFp](uint64_t cycles)
+    { return static_cast<uint64_t>((static_cast<unsigned __int128>(cycles) * nsPerCycleFp) >> SHIFT); };
+    const auto expectedCycles
+        = [cyclesPerNsFp](uint64_t ns) { return static_cast<uint64_t>((static_cast<unsigned __int128>(ns) * cyclesPerNsFp) >> SHIFT); };
+
+    EXPECT_EQ(Tsc::cyclesToNanoseconds(maxCyclesBeforeMultiplyOverflow), expectedNanoseconds(maxCyclesBeforeMultiplyOverflow));
+    EXPECT_EQ(Tsc::cyclesToNanoseconds(maxCyclesBeforeMultiplyOverflow + 1), expectedNanoseconds(maxCyclesBeforeMultiplyOverflow + 1));
+    EXPECT_EQ(Tsc::nanosecondsToCycles(maxNanosecondsBeforeMultiplyOverflow), expectedCycles(maxNanosecondsBeforeMultiplyOverflow));
+    EXPECT_EQ(Tsc::nanosecondsToCycles(maxNanosecondsBeforeMultiplyOverflow + 1), expectedCycles(maxNanosecondsBeforeMultiplyOverflow + 1));
+}
+
 TEST(Tsc, NanosecondsMatchWallClock)
 {
     uint64_t wall0 = getTimeNanoseconds();

--- a/src/util/tsc.cpp
+++ b/src/util/tsc.cpp
@@ -166,6 +166,8 @@ void Tsc::initialize() noexcept
     SILK_ASSERT(frequency != 0, "failed to determine TSC frequency");
     nsPerCycleFp = (1ULL << SHIFT) * 1'000'000'000 / frequency;
     cyclesPerNsFp = frequency * (1ULL << SHIFT) / 1'000'000'000;
+    maxCyclesBeforeMultiplyOverflow = UINT64_MAX / nsPerCycleFp;
+    maxNanosecondsBeforeMultiplyOverflow = UINT64_MAX / cyclesPerNsFp;
 }
 
 } // namespace silk


### PR DESCRIPTION
## What changed

- **Keep the fast path:** use the existing 64-bit fixed-point conversion for normal durations.
- **Handle long durations safely:** use a 128-bit intermediate only when the 64-bit multiplication could overflow.
- **Add regression coverage:** test a one-year duration and the threshold boundaries in both conversion directions.
- **Measure the hot path directly:** add short-input benchmarks for both conversion directions.
- **Document the limit:** conversion results and subsequent deadline arithmetic must fit in `uint64_t`; extreme values are not saturated.

## Why this matters

TSC conversion multiplies a duration by a fixed-point factor before shifting it down. The multiplication currently happens in `uint64_t`, so it can wrap before the final converted value would overflow.

This can affect real scheduler behavior. `FiberScheduler::sleep()` uses `nanosecondsToCycles()` to build deadlines and promises to sleep for at least the requested duration. With a 3 GHz counter, a 2-hour sleep can currently turn into roughly 22 minutes because of the wraparound.

The common short-duration path keeps the existing 64-bit multiply. Only long inputs use the wider fallback, so this fixes long deadlines without adding a 128-bit multiply to every conversion.

## Tests

- `./bb fmt --check`
- `./bb test -R Tsc`
- `build/release/bin/util-bench --benchmark_filter='TscBench/(GetNanoseconds|CyclesToNanosecondsShort|NanosecondsToCyclesShort)'`