### PR TITLE
Harden CI image build and add AI code-review job

### DIFF
--- a/ci/infrastructure/projects.py
+++ b/ci/infrastructure/projects.py
@@ -27,9 +27,14 @@ def _silk_ci_dependencies_component():
             # lock - both during this build (racing our own apt-get) and, once
             # the AMI is baked, at runner boot (racing the controller start).
             (
+                "echo 'DPkg::Lock::Timeout \"120\";' "
+                "> /etc/apt/apt.conf.d/99praktika-lock-timeout"
+            ),
+            (
                 "systemctl disable --now apt-daily.timer apt-daily-upgrade.timer "
                 "unattended-upgrades.service || true"
             ),
+            "systemctl stop apt-daily.service apt-daily-upgrade.service || true",
             (
                 "DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 "
                 "purge -y unattended-upgrades || true"
@@ -162,7 +167,7 @@ def _praktika_launch_user_data():
 
 
 def _image_builders():
-    image_recipe_version = "1.0.12"
+    image_recipe_version = "1.0.13"
     prebuilt_venvs = [
         ImageBuilder.PrebuiltVenv(
             name=PRAKTIKA_BASE_VENV,
@@ -215,6 +220,21 @@ _GH_TOKEN_MINTER = Components.GitHubTokenMinter(
 )
 _IMAGE_BUILDERS = _image_builders()
 _IMAGE_BUILDERS_BY_NAME = {builder.name: builder for builder in _IMAGE_BUILDERS}
+
+# The Code Review job (`praktika review`) calls an OpenAI model on Bedrock via
+# the Converse API, which requires bedrock:InvokeModel. Only the dedicated
+# code-review runner pool below carries this grant (scoped to Bedrock
+# foundation-model / inference-profile resources) - general job runners stay
+# Bedrock-less, so an arbitrary job cannot reach the model API.
+_CODE_REVIEW_BEDROCK_IAM_STATEMENT = {
+    "Sid": "BedrockRuntimeInference",
+    "Effect": "Allow",
+    "Action": ["bedrock:InvokeModel"],
+    "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*",
+    ],
+}
 
 PROJECTS = [
     CloudInfrastructure.Config(
@@ -331,6 +351,30 @@ PROJECTS = [
                 # the /silk/praktika-system CloudWatch stream; see praktika
                 # docs/logging.md.
                 ext={"system_logs": True},
+            ),
+            # Dedicated pool for the AI Code Review job. Identical to arm-small,
+            # plus a scoped bedrock:InvokeModel grant via ext["iam_statements"]
+            # so only this pool's role can call the Bedrock model API.
+            Components.RunnerPool(
+                name="arm-small-bedrock",
+                instance_type="t4g.medium",
+                scaling=Components.RunnerPool.Scaling.Auto,
+                size=0,
+                max_size=50,
+                volume_size_gb=100,
+                image_builder=_IMAGE_BUILDERS_BY_NAME["ci-arm64-image"],
+                allowed_ssm_parameters=[],
+                user_data=_praktika_launch_user_data(),
+                allowed_secrets=[],
+                allowed_s3_prefixes=["artifacts-eu-north-1"],
+                allow_all_ssm_parameters=False,
+                allow_all_secrets=False,
+                allow_all_s3_prefixes=False,
+                allow_ssm_debug=False,
+                ext={
+                    "system_logs": True,
+                    "iam_statements": [_CODE_REVIEW_BEDROCK_IAM_STATEMENT],
+                },
             ),
         ],
     )

--- a/ci/infrastructure/projects.py
+++ b/ci/infrastructure/projects.py
@@ -23,6 +23,17 @@ def _silk_ci_dependencies_component():
         "description": "Install Silk CI toolchains and build dependencies",
         "commands": [
             "export DEBIAN_FRONTEND=noninteractive",
+            # Stop stock Ubuntu background apt upgrades from holding the dpkg
+            # lock - both during this build (racing our own apt-get) and, once
+            # the AMI is baked, at runner boot (racing the controller start).
+            (
+                "systemctl disable --now apt-daily.timer apt-daily-upgrade.timer "
+                "unattended-upgrades.service || true"
+            ),
+            (
+                "DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 "
+                "purge -y unattended-upgrades || true"
+            ),
             (
                 "wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key "
                 "> /etc/apt/trusted.gpg.d/apt.llvm.org.asc"
@@ -151,7 +162,7 @@ def _praktika_launch_user_data():
 
 
 def _image_builders():
-    image_recipe_version = "1.0.11"
+    image_recipe_version = "1.0.12"
     prebuilt_venvs = [
         ImageBuilder.PrebuiltVenv(
             name=PRAKTIKA_BASE_VENV,

--- a/ci/prompts/code_review.md
+++ b/ci/prompts/code_review.md
@@ -1,0 +1,38 @@
+# Silk code-review guidance
+
+Project-specific guidance for the `praktika review` job. This is appended to the
+fixed review protocol; keep it focused on what a generic reviewer would not know
+about this repository.
+
+## What this repo is
+Silk is a cooperative fiber scheduler for Linux: per-CPU scheduler threads
+pinned to cores, io_uring-based async IO, topology-aware work stealing, and
+fiber synchronization primitives (futures, events, mutexes, futexes, sequencers,
+multi-locks), plus a utility library (lock-free structures, memory pools, TSC
+timing, perf counters, a BPF profiler). It is C++ and performance is a
+correctness requirement. The design docs under `docs/` are the source of truth.
+
+## What to prioritise
+- **Concurrency correctness**: this is the heart of the project. Flag data
+  races, missing or wrong memory ordering, ABA hazards, and lifetime bugs in the
+  lock-free fast paths (sharded-stack, memory-pool, the queues, rseq sequences).
+  compare_exchange must be the weak form. A fiber must never extend its 64 KiB
+  stack. Fire-then-wait on a future is a synchronization bug; synchronize with
+  `future = nullptr`.
+- **Performance regressions on hot paths**: no allocations, no std containers or
+  strings, no exceptions in library code. Steady-state memory comes from pools
+  and preallocated per-CPU state. Flag anything that allocates, locks, or
+  syscalls on a steady-state scheduling path.
+- **Error handling**: the model is errno-only (`noexcept` + `int` returns, no
+  exceptions, no Result<T>). After a failing syscall, errno must be captured
+  immediately before any call that could clobber it. Errors propagate through the
+  SILK_CHECK_* macros and a trailing `silk::Error *`; a bare errno stays bare.
+
+## What to skip
+- Formatting, naming, and lint nits - other jobs and CLAUDE.md cover these.
+- Speculative refactors unrelated to the diff, and touching the delicate
+  lock-free fast paths beyond the diff's explicit scope.
+
+## Style
+- Prefer a small number of high-signal findings over many low-value ones.
+- When you flag something, say concretely how it fails (inputs -> wrong outcome).

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -4,6 +4,7 @@ class RunnerLabels:
     MEDIUM_ARM = "arm-medium"
     MEDIUM_AMD = "amd-medium"
     LARGE_ARM = "arm-large"
+    SMALL_ARM_BEDROCK = "arm-small-bedrock"
 
 
 PROJECT_NAME = "silk"

--- a/ci/workflows/jobs.py
+++ b/ci/workflows/jobs.py
@@ -16,6 +16,18 @@ FMT_JOB = Job.Config(
     ),
 )
 
+CODE_REVIEW_JOB = Job.Config(
+    name="Code Review",
+    runs_on=[RunnerLabels.SMALL_ARM_BEDROCK],
+    command=(
+        "python3 -I -m praktika review --provider bedrock-openai "
+        "--model global.openai.gpt-5.6-sol --reasoning-effort high "
+        "--prompt ./ci/prompts/code_review.md"
+    ),
+    allow_failure=True,
+    enable_gh_auth=True,
+)
+
 TEST_DIGEST = Job.CacheDigestConfig(
     include_paths=[
         "src",

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -1,5 +1,11 @@
 from praktika import Workflow
-from ci.workflows.jobs import BUILD_VARIANTS, FMT_JOB, TEST_AMD, TEST_ARM
+from ci.workflows.jobs import (
+    BUILD_VARIANTS,
+    CODE_REVIEW_JOB,
+    FMT_JOB,
+    TEST_AMD,
+    TEST_ARM,
+)
 
 WORKFLOWS = [
     Workflow.Config(
@@ -8,6 +14,7 @@ WORKFLOWS = [
         base_branches=["main"],
         jobs=[
             FMT_JOB.copy(),
+            CODE_REVIEW_JOB.copy(),
             *TEST_ARM.parametrize(*BUILD_VARIANTS),
             *TEST_AMD.parametrize(*BUILD_VARIANTS),
         ],


### PR DESCRIPTION
Mirrors two upstream changes into silk's CI, adapted to silk's conventions.

## Image-build hardening (mirrors ClickHouse/praktika#141)
- Add `unattended-upgrades` removal and disable the `apt-daily`/`apt-daily-upgrade`/`unattended-upgrades` units in the silk CI dependencies component, before its first `apt-get`. This stops stock Ubuntu background upgrades from holding the dpkg lock during the image build and, once the AMI is baked, at runner boot. Both commands carry `|| true` so a missing package or transient apt failure never aborts the build.
- Bump `image_recipe_version` `1.0.11` -> `1.0.12` so a fresh AMI is actually baked with the changed component content.

Note: praktika is consumed here as a pinned wheel, so the upstream fixes to praktika's own `gh.py` (Pages-root clean) and base `_ubuntu_setup_component` are not vendored in silk. This applies the same hardening to silk's own Ubuntu setup component instead.

## AI code-review job
- New `CODE_REVIEW_JOB` running `praktika review` against an OpenAI model on Bedrock, with `allow_failure=True` (a review hiccup never blocks merge) and `enable_gh_auth=True` (so it can post its review), wired into the `PR` workflow.
- New `RunnerLabels.SMALL_ARM_BEDROCK` label and a dedicated `arm-small-bedrock` runner pool. Based on silk's existing `arm-small` pool (keeping the locked-down `allow_all_*=False` posture and `system_logs`), plus a scoped `bedrock:InvokeModel` IAM statement merged into `ext["iam_statements"]`, so only this pool's role can reach the Bedrock model API. General job runners stay Bedrock-less.
- New silk-specific `ci/prompts/code_review.md`: fiber-scheduler concurrency and lock-free correctness, hot-path performance discipline, and the errno-only error model.

## To confirm before merge
- The `global.openai.gpt-5.6-sol` Bedrock inference profile is reachable from `eu-north-1` (Bedrock model availability is region-specific).