### PR TITLE
Fail loud when a completion callback blocks the scheduler thread

### DIFF
--- a/src/fibers/fiber.cpp
+++ b/src/fibers/fiber.cpp
@@ -79,6 +79,11 @@ thread_local Fiber * threadFiber = nullptr;
 // Proxy fiber for the current non-fiber thread; destroyed at thread exit.
 static thread_local std::unique_ptr<Fiber> proxyFiber;
 
+// Set for the lifetime of a scheduler thread. A scheduler thread must never block
+// on the proxy path - a blocked scheduler thread stops draining its ring and wedges
+// the processor - so the proxy park fails loud when this is set.
+static thread_local bool schedulerThread = false;
+
 Fiber::Fiber(bool isProxyFiber) noexcept
     : state(isProxyFiber ? FiberState::RUNNING : FiberState::SUSPENDED)
     , isProxyFiber(isProxyFiber)
@@ -334,6 +339,12 @@ void Fiber::wakeThread() noexcept
 
 void Fiber::parkThread() noexcept
 {
+    // Only external threads may block through the proxy. On a scheduler thread this
+    // park means a completion callback or another thread-context hook issued a
+    // blocking call inside the service loop - the processor would stop draining its
+    // ring until someone else completes the wait.
+    SILK_ASSERT(!schedulerThread, "a completion callback blocked the scheduler thread");
+
     Perf::getSimpleCounter(simpleCounters[PROXY_FIBER_PARKED]).increment();
 
     for (;;)
@@ -1701,6 +1712,8 @@ LatencyReport FiberScheduler::reportLatency(ProfileEventKind kind, uint8_t categ
 
 void FiberScheduler::runScheduler(ProcessorState * processor) noexcept
 {
+    schedulerThread = true;
+
     int r = pinThreadToCpu(processor->number);
     SILK_ASSERT(!r, "could not pin the scheduler thread to its cpu: r=%d", r);
 

--- a/src/fibers/tests/future-test.cpp
+++ b/src/fibers/tests/future-test.cpp
@@ -1,11 +1,14 @@
 #include <silk/fibers/future.h>
 
 #include <silk/fibers/fiber.h>
+#include <silk/util/platform.h>
 
 #include <gtest/gtest.h>
 
 #include <cerrno>
 #include <vector>
+
+#include <unistd.h>
 
 namespace silk
 {
@@ -452,6 +455,43 @@ TEST(FiberFuture, setAllNoWaiter)
 TEST(FiberFuture, setAllEmpty)
 {
     FiberFuture::setAll(0, nullptr, 0);
+}
+
+/** Violates the subscribe contract - the callback must not block. */
+static void blockingSubscribeCallback(FiberFuture * future) noexcept
+{
+    SILK_UNUSED(future);
+    FiberScheduler::sleep(1'000'000);
+}
+
+static int emptyFiberMain(int * params) noexcept
+{
+    SILK_UNUSED(params);
+    return 0;
+}
+
+// The fiber-completion future is set by the scheduler thread, so the subscribed
+// callback runs there; its blocking sleep takes the proxy park, which must fail
+// loud instead of wedging the processor.
+TEST(FutureDeathTest, blockingSubscribeCallbackFailsOnSchedulerThread)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    ASSERT_DEATH(
+        {
+            FiberFuture future;
+            bool subscribed = future.subscribe(blockingSubscribeCallback);
+            ASSERT_TRUE(subscribed);
+
+            int r = FiberScheduler::run(emptyFiberMain, 0, &future);
+            ASSERT_EQ(r, 0);
+
+            // The assert fires on a scheduler thread while this thread sleeps; the
+            // crash dump before the re-raise can take seconds, and the child exits
+            // clean the moment this statement returns - so outwait any dump.
+            ::usleep(60'000'000);
+        },
+        "a completion callback blocked the scheduler thread");
 }
 
 } // namespace silk


### PR DESCRIPTION
A subscribed callback runs on the thread that sets the future; a blocking call there takes the proxy park and stops the processor from draining its ring. The proxy park now asserts on scheduler threads, enforcing the documented must-not-block contract at its choke point.