### PR TITLE
Batch FiberCondVar notify_all wakeups

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -136,7 +136,7 @@ cv.notify_one();   // or cv.notify_all()
 
 **wait_for** -- `cv.wait_for(lock, nanoseconds)` returns 0 on a notify-driven wakeup or `ETIMEDOUT` on timeout. Implemented via `FiberFuture::waitWithTimeout`; on timeout the future cancels itself, which removes it from the waiter list. A notify that races at the boundary may consume our future but `wait_for` still returns `ETIMEDOUT` -- the predicate re-check handles the lost wakeup, per the usual cv contract.
 
-**Cancel/notify race** -- a single `inWaiters` bool per waiter, read and written only under `spinLock`, serializes timeout-triggered self-cancel against `notify_one` / `notify_all`. Exactly one of those paths removes the future from the list and calls `set()`; the other observes `inWaiters` is false and bails. `notify_all` splices the waiter list into a local snapshot and clears `inWaiters` on each, all under the lock; the actual `set(0)` calls fire outside the lock.
+**Cancel/notify race** -- a single `inWaiters` bool per waiter, read and written only under `spinLock`, serializes timeout-triggered self-cancel against `notify_one` / `notify_all`. Exactly one of those paths removes the future from the list and completes it; the other observes `inWaiters` is false and bails. `notify_all` splices the waiter list into a local snapshot and clears `inWaiters` on each, all under the lock; the actual future completions fire outside the lock.
 
 ---
 

--- a/include/silk/fibers/condvar.h
+++ b/include/silk/fibers/condvar.h
@@ -41,7 +41,7 @@ public:
         // True while this Future is linked in FiberCondVar::waiters. Read and
         // written only under spinLock; serializes cancel() vs notify_one() /
         // notify_all() so exactly one path removes the future from the list
-        // and calls set().
+        // and completes it.
         bool inWaiters = false;
     };
 

--- a/src/fibers/benchmarks/condvar-bench.cpp
+++ b/src/fibers/benchmarks/condvar-bench.cpp
@@ -7,6 +7,7 @@
 #include <benchmark/benchmark.h>
 
 #include <atomic>
+#include <vector>
 
 namespace silk
 {
@@ -153,9 +154,9 @@ BENCHMARK_F(FiberCondVarBench, RoundTrip)(benchmark::State & state)
 // fires notify_all() and waits for every waiter to retire, then the cycle
 // repeats. Each iteration = N waiters suspending + one notify_all that wakes
 // them all + the driver re-checking the count.
-BENCHMARK_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
+BENCHMARK_DEFINE_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
 {
-    static constexpr int N = 8;
+    int waiterCount = static_cast<int>(state.range(0));
 
     struct Shared
     {
@@ -164,6 +165,7 @@ BENCHMARK_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
         FiberMutex mutex;
         int generation = 0;
         int doneCount = 0;
+        int waiterCount = 0;
         std::atomic<bool> stop{false};
     };
 
@@ -212,7 +214,7 @@ BENCHMARK_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
                 s->startSignal.notify_all();
 
                 s->mutex.lock();
-                while (s->doneCount != N)
+                while (s->doneCount != s->waiterCount)
                 {
                     s->doneSignal.wait(s->mutex);
                 }
@@ -223,8 +225,10 @@ BENCHMARK_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
     };
 
     Shared shared;
-    FiberFuture waiters[N], driver;
-    for (int i = 0; i < N; ++i)
+    shared.waiterCount = waiterCount;
+    std::vector<FiberFuture> waiters(waiterCount);
+    FiberFuture driver;
+    for (int i = 0; i < waiterCount; ++i)
     {
         int r = FiberScheduler::run(Waiter::fiberMain, {&shared}, &waiters[i]);
         SILK_ASSERT(!r);
@@ -239,10 +243,11 @@ BENCHMARK_F(FiberCondVarBench, NotifyAllWakesN)(benchmark::State & state)
     shared.mutex.unlock();
     shared.startSignal.notify_all();
 
-    for (int i = 0; i < N; ++i)
+    for (int i = 0; i < waiterCount; ++i)
     {
         waiters[i].wait();
     }
 }
+BENCHMARK_REGISTER_F(FiberCondVarBench, NotifyAllWakesN)->Arg(1)->Arg(8)->Arg(64);
 
 } // namespace silk

--- a/src/fibers/condvar.cpp
+++ b/src/fibers/condvar.cpp
@@ -47,9 +47,23 @@ void FiberCondVar::notify_all() noexcept
 
     spinLock.unlock();
 
+    constexpr uint64_t WAKE_BATCH = 32;
+    FiberFuture * wakeBatch[WAKE_BATCH];
+    uint64_t batchSize = 0;
+
     while (Future * future = snapshot.pop_front())
     {
-        future->set(0);
+        wakeBatch[batchSize++] = future;
+        if (batchSize == WAKE_BATCH)
+        {
+            FiberFuture::setAll(0, wakeBatch, batchSize);
+            batchSize = 0;
+        }
+    }
+
+    if (batchSize)
+    {
+        FiberFuture::setAll(0, wakeBatch, batchSize);
     }
 }
 

--- a/src/fibers/tests/condvar-test.cpp
+++ b/src/fibers/tests/condvar-test.cpp
@@ -53,7 +53,7 @@ TEST(FiberCondVar, notifyOneWakesWaiter)
 
 TEST(FiberCondVar, notifyAllWakesAll)
 {
-    static constexpr int N = 4;
+    static constexpr int N = 33;
 
     struct Params
     {


### PR DESCRIPTION
## What

- Batch `FiberCondVar::notify_all()` wakeups through `FiberFuture::setAll()`.
- Keep the existing waiter snapshot and cancellation behavior.
- Update the condvar comments to describe completion instead of `set()`.
- Cover 1, 8, and 64 waiters in the existing `NotifyAllWakesN` benchmark.
- Increase `notifyAllWakesAll` to 33 waiters to cover a full wake batch and the tail.

## Why

`notify_all()` was calling `set(0)` once per waiter. `FiberSequencer` already batches the same kind of wakeups through `setAll()`, so this applies that path to condvar broadcasts too.

## Benchmark

Command: `fibers-bench --benchmark_filter=FiberCondVarBench/NotifyAllWakesN --benchmark_min_time=1s --benchmark_repetitions=5`

Median wall time per iteration from one 4-CPU run:

| Waiters | Base | Patch |
| ---: | ---: | ---: |
| 1 | 252 ns | 261 ns |
| 8 | 2.67 us | 15.83 us |
| 64 | 8.12 us | 8.94 us |

The VM run was noisy, so these numbers are only a reference point. They are included so the before/after result is visible.

## Checks

- `fibers-test --gtest_filter=FiberCondVar.*` passed all 11 condvar tests.
- `git diff --cached --check` passed.
