### PR TITLE
Avoid overflow in Bitmap::wordCount

### DIFF
--- a/include/silk/util/bitmap.h
+++ b/include/silk/util/bitmap.h
@@ -22,7 +22,7 @@ public:
     }
 
     /** Number of 64-bit words a bitmap of bitCount bits occupies. */
-    static constexpr uint32_t wordCount(uint32_t bitCount) noexcept { return alignUp(bitCount, WORD_BITS) / WORD_BITS; }
+    static constexpr uint32_t wordCount(uint32_t bitCount) noexcept { return bitCount / WORD_BITS + (bitCount % WORD_BITS != 0); }
 
     /** True if the bit at index is set. */
     bool test(uint32_t index) const noexcept { return (words[index / WORD_BITS] >> (index % WORD_BITS)) & 1; }

--- a/src/util/tests/bitmap-test.cpp
+++ b/src/util/tests/bitmap-test.cpp
@@ -30,7 +30,17 @@ TEST(BitmapTest, WordCount)
         uint32_t expected;
     };
 
-    const Case cases[] = {{0, 0}, {1, 1}, {64, 1}, {65, 2}, {128, 2}, {129, 3}};
+    const Case cases[] = {
+        {0, 0},
+        {1, 1},
+        {64, 1},
+        {65, 2},
+        {128, 2},
+        {129, 3},
+        {UINT32_MAX - 63, 67'108'863},
+        {UINT32_MAX - 62, 67'108'864},
+        {UINT32_MAX, 67'108'864},
+    };
 
     for (const Case & testCase : cases)
     {


### PR DESCRIPTION
## What changed

- Calculate the bitmap word count with division and remainder.
- Add boundary tests around `UINT32_MAX`.

## Why

`alignUp(uint32_t)` adds 63 before rounding. Near `UINT32_MAX`, that addition wraps and `Bitmap::wordCount()` can return 0 for a bitmap that needs 67,108,864 words.

## Tests

- Added boundary cases to `BitmapTest.WordCount`.
- Checked the diff with `git diff --check`.
- Verified the boundary values with Clang compile-time assertions.