### PR TITLE
Detach BPF links when stopping profiler

### DIFF
--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -182,6 +182,11 @@ void Profiler::stop() noexcept
         bpf_link__destroy(link);
     }
     perfLinks.clear();
+
+    if (skel)
+    {
+        profiler_bpf__detach(skel);
+    }
 }
 
 void Profiler::emitFoldedStacks(Symbolizer * symbolizer)


### PR DESCRIPTION
## What changed

- Detach links owned by the generated BPF skeleton in `Profiler::stop()`.
- Keep the maps available for folded-stack collection.

## Why

`stop()` only destroyed manually attached perf-event links. The off-CPU `sched_switch` program is attached by `profiler_bpf__attach(skel)`, so it kept running while `emitFoldedStacks()` collected results.

## Testing

- Checked the diff with `git diff --check`.