### PR TITLE
Avoid divide by zero in off-CPU mode

### DIFF
--- a/src/profiler/main.cpp
+++ b/src/profiler/main.cpp
@@ -116,6 +116,12 @@ int main(int argc, char ** argv)
         return 1;
     }
 
+    if (oncpu && sampleHz == 0)
+    {
+        SILK_ERROR("on-CPU sampling frequency must be greater than zero");
+        return 1;
+    }
+
     bool hasBpf = hasCapability(CAP_BPF);
     bool hasPerfmon = hasCapability(CAP_PERFMON);
 

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -197,12 +197,14 @@ void Profiler::emitFoldedStacks(Symbolizer * symbolizer)
     int oncpuFd = bpf_map__fd(skel->maps.oncpu);
     int offcpuFd = bpf_map__fd(skel->maps.offcpu);
 
-    uint64_t sampleNs = 1'000'000'000ULL / sampleHz;
-
     // Merge both maps into {stack_key → (on_ns, off_ns)}.
     std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> merged;
 
-    drainStacks(oncpuFd, merged, true, sampleNs);
+    if (oncpu)
+    {
+        uint64_t sampleNs = 1'000'000'000ULL / sampleHz;
+        drainStacks(oncpuFd, merged, true, sampleNs);
+    }
     drainStacks(offcpuFd, merged, false, 1);
 
     std::string folded;


### PR DESCRIPTION
## Summary

- **Allow** `--off-cpu --hz 0` without crashing during collection.
- **Reject** zero on-CPU frequency before BPF setup.
- **Skip** unused on-CPU map conversion in off-CPU-only mode.

## Validation

- `git diff --check`