### PR TITLE
Prevent perf counter registration overflow

### DIFF
--- a/src/util/perf.cpp
+++ b/src/util/perf.cpp
@@ -47,7 +47,7 @@ int Perf::registerSimpleCounters(CounterGroup * group, const char ** names, uint
     uint32_t base = simpleCounterCount.load(std::memory_order_relaxed);
     for (;;)
     {
-        if (base + count > NUM_SIMPLE_COUNTERS)
+        if (count > NUM_SIMPLE_COUNTERS - base)
         {
             return ENOMEM;
         }
@@ -101,7 +101,7 @@ int Perf::registerMemCounters(CounterGroup * group, const char ** names, uint32_
     uint32_t base = memCounterCount.load(std::memory_order_relaxed);
     for (;;)
     {
-        if (base + count > NUM_MEM_COUNTERS)
+        if (count > NUM_MEM_COUNTERS - base)
         {
             return ENOMEM;
         }

--- a/src/util/tests/perf-test.cpp
+++ b/src/util/tests/perf-test.cpp
@@ -152,6 +152,17 @@ TEST_F(PerfTest, OverflowReturnsENOMEM)
     EXPECT_EQ(Perf::registerSimpleCounter(&overflow, "overflow"), ENOMEM);
 }
 
+TEST_F(PerfTest, CounterRegistrationCountOverflowReturnsENOMEM)
+{
+    const char * names[] = {"overflow"};
+    Perf::CounterGroup group;
+    ASSERT_EQ(Perf::registerSimpleCounters(&group, names, 1), 0);
+
+    Perf::CounterGroup overflow;
+    EXPECT_EQ(Perf::registerSimpleCounters(&overflow, names, UINT32_MAX), ENOMEM);
+    EXPECT_EQ(Perf::getSimpleCounterCount(), 1u);
+}
+
 TEST_F(PerfTest, DestroyResetsCounterCount)
 {
     const char * names[] = {"A"};
@@ -357,6 +368,17 @@ TEST_F(PerfTest, MemCounterOverflowReturnsENOMEM)
 
     Perf::CounterGroup overflow;
     EXPECT_EQ(Perf::registerMemCounter(&overflow, "overflow"), ENOMEM);
+}
+
+TEST_F(PerfTest, MemCounterRegistrationCountOverflowReturnsENOMEM)
+{
+    const char * names[] = {"overflow"};
+    Perf::CounterGroup group;
+    ASSERT_EQ(Perf::registerMemCounters(&group, names, 1), 0);
+
+    Perf::CounterGroup overflow;
+    EXPECT_EQ(Perf::registerMemCounters(&overflow, names, UINT32_MAX), ENOMEM);
+    EXPECT_EQ(Perf::getMemCounterCount(), 1u);
 }
 
 TEST_F(PerfTest, DestroyResetsMemCounterCount)


### PR DESCRIPTION
## Summary

- **Avoids uint32_t wraparound** when checking remaining simple and memory counter slots.
- Returns `ENOMEM` before changing the registered count or writing counter metadata.
- Adds regression coverage for requesting `UINT32_MAX` slots after one slot is registered.

## Tests

- Targeted perf counter overflow smoke test
- `perf-test.cpp` syntax check
- `git diff --check`