### PR TITLE
Destroy all MemoryPool objects on teardown

### DIFF
--- a/include/silk/util/memory-pool.h
+++ b/include/silk/util/memory-pool.h
@@ -60,6 +60,7 @@ private:
     //
 
     uint32_t slotsOffset() const noexcept { return alignUp<uint32_t>(sizeof(Chunk), alignment); }
+    uint32_t slotsPerChunk() const noexcept { return (chunkSize - slotsOffset()) / objectSize; }
     Chunk * allocateChunk() noexcept;
     void freeChunk(Chunk * chunk) noexcept;
 

--- a/src/util/memory-pool.cpp
+++ b/src/util/memory-pool.cpp
@@ -16,7 +16,7 @@ MemoryPoolBase::MemoryPoolBase(
     , stackEntryOffset(stackEntryOffset)
     , initialize(initialize)
     , destroy(destroy)
-    , stack((chunkSize - slotsOffset()) / this->objectSize)
+    , stack(slotsPerChunk())
 {
     uint32_t processorCount = getProcessorCount();
     for (uint32_t i = 0; i < processorCount; ++i)
@@ -28,13 +28,20 @@ MemoryPoolBase::MemoryPoolBase(
 
 MemoryPoolBase::~MemoryPoolBase() noexcept
 {
-    if (destroy)
-    {
-        stack.drain([](StackEntry * entry, void * ctx) noexcept { static_cast<MemoryPoolBase *>(ctx)->destroy(entry); }, this);
-    }
+    stack.drain([](StackEntry *, void *) noexcept { }, nullptr);
 
     while (Chunk * chunk = chunks.pop())
     {
+        if (destroy)
+        {
+            uint8_t * slots = reinterpret_cast<uint8_t *>(chunk) + slotsOffset();
+            for (uint32_t i = 0; i < slotsPerChunk(); ++i)
+            {
+                StackEntry * entry = reinterpret_cast<StackEntry *>(slots + i * objectSize + stackEntryOffset);
+                destroy(entry);
+            }
+        }
+
         freeChunk(chunk);
     }
 }
@@ -75,7 +82,7 @@ MemoryPoolBase::Chunk * MemoryPoolBase::allocateChunk() noexcept
     StackEntry * tail = nullptr;
 
     uint32_t offset = slotsOffset();
-    uint32_t freelistSize = (chunkSize - offset) / objectSize;
+    uint32_t freelistSize = slotsPerChunk();
 
     uint8_t * slots = reinterpret_cast<uint8_t *>(chunk) + offset;
     for (uint32_t i = 0; i < freelistSize; ++i)

--- a/src/util/tests/memory-pool-test.cpp
+++ b/src/util/tests/memory-pool-test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <thread>
 #include <unordered_set>
 #include <vector>
@@ -16,6 +17,18 @@ struct MyObject
 };
 
 using MyPool = MemoryPool<MyObject, &MyObject::stackEntry>;
+
+struct TrackedObject
+{
+    StackEntry stackEntry;
+    static inline uint32_t constructed = 0;
+    static inline uint32_t destroyed = 0;
+
+    TrackedObject() { ++constructed; }
+    ~TrackedObject() { ++destroyed; }
+};
+
+using TrackedPool = MemoryPool<TrackedObject, &TrackedObject::stackEntry>;
 
 TEST(MemoryPool, AllocateReturnsNonNull)
 {
@@ -36,6 +49,23 @@ TEST(MemoryPool, ObjectIsInitialized)
     EXPECT_EQ(object->value, 0);
 
     pool.deallocate(object);
+}
+
+TEST(MemoryPool, DestroyCallsDestructorsForCheckedOutObjects)
+{
+    TrackedObject::constructed = 0;
+    TrackedObject::destroyed = 0;
+    uint32_t constructed;
+
+    {
+        TrackedPool pool;
+        ASSERT_NE(pool.allocate(), nullptr);
+        constructed = TrackedObject::constructed;
+        EXPECT_GT(constructed, 0u);
+        EXPECT_EQ(TrackedObject::destroyed, 0u);
+    }
+
+    EXPECT_EQ(TrackedObject::destroyed, constructed);
 }
 
 TEST(MemoryPool, AllocateDeallocateReusesSlot)


### PR DESCRIPTION
## Summary

- **Destroy every object slot** when a `MemoryPool` is torn down, including checked-out objects.
- Detach free-list entries before releasing their chunks.
- Add a regression test for a checked-out object destructor.

## Tests

- `git diff --check`
- GitHub CI