### PR TITLE
Fix spurious try_lock_shared failures under shared contention

### DIFF
--- a/include/silk/fibers/mutex.h
+++ b/include/silk/fibers/mutex.h
@@ -87,17 +87,21 @@ public:
 
     /**
      * Attempt to acquire a shared lock without suspending; returns true on success. Respects
-     * writer priority - returns false if any exclusive waiter is queued.
+     * writer priority - returns false only when the lock is held exclusive or an exclusive
+     * waiter is queued; racing shared lockers retry, never a spurious failure.
      */
     [[nodiscard]] bool try_lock_shared() noexcept
     {
         State currentState;
         currentState.raw = state.load(std::memory_order_relaxed);
-        if (!currentState.exclusive && !currentState.hasExclusiveWaiters)
+        while (!currentState.exclusive && !currentState.hasExclusiveWaiters)
         {
             State newState(currentState);
             newState.value = currentState.value + 1;
-            return state.compare_exchange_weak(currentState.raw, newState.raw, std::memory_order_acquire, std::memory_order_relaxed);
+            if (state.compare_exchange_weak(currentState.raw, newState.raw, std::memory_order_acquire, std::memory_order_relaxed))
+            {
+                return true;
+            }
         }
         return false;
     }

--- a/src/fibers/tests/mutex-test.cpp
+++ b/src/fibers/tests/mutex-test.cpp
@@ -292,6 +292,45 @@ TEST(FiberMutex, sharedDoesNotExcludeShared)
     }
 }
 
+// With no exclusive holder or waiter anywhere, a try_lock_shared losing its CAS to a racing
+// shared locker must retry inside the try, never surface the race as a failure.
+TEST(FiberMutex, tryLockSharedNeverFailsAgainstSharedLockers)
+{
+    static constexpr int N_FIBERS = 8;
+    static constexpr uint32_t N_ROUNDS = 100'000;
+
+    struct Params
+    {
+        FiberMutex * mutex;
+
+        static int fiberMain(Params * p) noexcept
+        {
+            for (uint32_t i = 0; i < N_ROUNDS; ++i)
+            {
+                bool acquired = p->mutex->try_lock_shared();
+                SILK_ASSERT(acquired, "try_lock_shared failed with only shared lockers racing: i=%u", i);
+                p->mutex->unlock_shared();
+            }
+
+            return 0;
+        }
+    };
+
+    FiberMutex mutex;
+    FiberFuture futures[N_FIBERS];
+
+    for (int i = 0; i < N_FIBERS; ++i)
+    {
+        int r = FiberScheduler::run(Params::fiberMain, {&mutex}, &futures[i]);
+        ASSERT_FALSE(r);
+    }
+
+    for (int i = 0; i < N_FIBERS; ++i)
+    {
+        futures[i].wait();
+    }
+}
+
 TEST(FiberMutex, sharedWakesAfterExclusiveRelease)
 {
     struct ReaderParams


### PR DESCRIPTION
try_lock_shared attempted one compare_exchange_weak, so a racing shared locker bumping the holder count - or a spurious weak-CAS failure - returned false on a lock free for sharing. The CAS now retries while the observed state permits sharing, so false means exactly an exclusive holder or a queued exclusive waiter.