### PR TITLE
Make platform.h work on any libc with the standard rseq ABI

### DIFF
--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -199,14 +199,23 @@ static constexpr uint64_t intHash(uint64_t key) noexcept
     return key;
 }
 
+/** @{ Overloads dispatching on the actual return type of ::strerror_r: the GNU variant
+ * returns char *, the POSIX one returns int. Selecting by feature-test macros misfires
+ * on libcs that accept _GNU_SOURCE but only ship the POSIX variant. */
+[[maybe_unused]] static inline const char * strerrorResult(int r, char * buf) noexcept
+{
+    return r == 0 ? buf : nullptr;
+}
+[[maybe_unused]] static inline const char * strerrorResult(const char * r, char *) noexcept
+{
+    return r;
+}
+/** @} */
+
 /** Thread-safe strerror_r into a caller-provided buffer; may return nullptr for an unknown code. */
 static inline const char * strerror(int code, char * buf, size_t size) noexcept
 {
-#if defined(_GNU_SOURCE)
-    return ::strerror_r(code, buf, size);
-#else
-    return ::strerror_r(code, buf, size) == 0 ? buf : nullptr;
-#endif
+    return strerrorResult(::strerror_r(code, buf, size), buf);
 }
 
 } // namespace silk

--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -8,26 +8,32 @@
 #include <cstring>
 
 #include <sched.h>
+#include <stddef.h>
 #include <time.h>
 #include <unistd.h>
 
 /**
- * On older sysroots we fall back to a minimal in-tree `struct rseq` matching
- * the kernel UAPI layout (cpu_id_start at offset 0, cpu_id at offset 4) and
- * alias `__rseq_offset` to librseq's `rseq_offset`, which librseq populates.
+ * On sysroots without sys/rseq.h we fall back to a minimal in-tree struct rseq
+ * matching the kernel UAPI layout (cpu_id_start at offset 0, cpu_id at offset 4).
  */
 #if __has_include(<sys/rseq.h>)
 #    include <sys/rseq.h>
 #else
-#    include <stddef.h>
 struct rseq
 {
     uint32_t cpu_id_start;
     uint32_t cpu_id;
 };
-extern "C" ptrdiff_t rseq_offset;
-#    define __rseq_offset rseq_offset
 #endif
+
+/**
+ * @{ librseq's copies of the libc rseq ABI values, populated by rseq_init.
+ * Reading them instead of the libc __rseq_offset/__rseq_size symbols keeps the
+ * behavior tied to the runtime libc rather than the build-time sysroot headers.
+ */
+extern "C" ptrdiff_t rseq_offset;
+extern "C" unsigned int rseq_size;
+/** @} */
 
 /** Suppress unused-variable warnings. */
 #define SILK_UNUSED(x) (void)(x)
@@ -147,11 +153,26 @@ static inline uint16_t getCurrentProcessor() noexcept
 #    error Unsupported platform
 #endif
 
-    // glibc's sched_getcpu fast path is THREAD_GETMEM_VOLATILE(THREAD_SELF, rseq_area.cpu_id),
-    // which is the same rseq read we do here. We skip the function call and the cpu_id >= 0
-    // fallback to vDSO/syscall -- safe on Linux 4.18+ / glibc 2.35+ where rseq is always registered.
-    struct rseq * rseq = reinterpret_cast<struct rseq *>(threadPointer + __rseq_offset);
-    return static_cast<uint16_t>(rseq->cpu_id);
+    // The rseq read matches glibc's sched_getcpu fast path. rseq_offset is meaningful only
+    // after rseq_init copied the libc ABI values into librseq's globals: rseq_size starts
+    // at -1U, becomes 0 when the libc registration failed, and is positive on success - the
+    // signed cast rejects the first two. cpu_id is negative on a thread whose rseq area is
+    // not registered (kernel sentinels for unregistered and registration-failed threads).
+    if (static_cast<int32_t>(rseq_size) > 0)
+    {
+        struct rseq * rseq = reinterpret_cast<struct rseq *>(threadPointer + rseq_offset);
+        int32_t rseqCpu = static_cast<int32_t>(rseq->cpu_id);
+
+        if (rseqCpu >= 0)
+        {
+            return static_cast<uint16_t>(rseqCpu);
+        }
+    }
+
+    // sched_getcpu is vDSO-backed on common libcs, so the fallback stays cheap. The CPU id
+    // is a sharding hint - clamping a failure to shard 0 is functionally correct.
+    int cpu = ::sched_getcpu();
+    return cpu >= 0 ? static_cast<uint16_t>(cpu) : 0;
 }
 
 /** Yield the calling thread's remaining timeslice to the OS scheduler. */

--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -8,32 +8,25 @@
 #include <cstring>
 
 #include <sched.h>
-#include <stddef.h>
 #include <time.h>
 #include <unistd.h>
 
 /**
  * On sysroots without sys/rseq.h we fall back to a minimal in-tree struct rseq
- * matching the kernel UAPI layout (cpu_id_start at offset 0, cpu_id at offset 4).
+ * matching the kernel UAPI layout (cpu_id_start at offset 0, cpu_id at offset 4)
+ * and declare the standard libc ABI symbol ourselves.
  */
 #if __has_include(<sys/rseq.h>)
 #    include <sys/rseq.h>
 #else
+#    include <stddef.h>
 struct rseq
 {
     uint32_t cpu_id_start;
     uint32_t cpu_id;
 };
+extern "C" ptrdiff_t __rseq_offset;
 #endif
-
-/**
- * @{ librseq's copies of the libc rseq ABI values, populated by rseq_init.
- * Reading them instead of the libc __rseq_offset/__rseq_size symbols keeps the
- * behavior tied to the runtime libc rather than the build-time sysroot headers.
- */
-extern "C" ptrdiff_t rseq_offset;
-extern "C" unsigned int rseq_size;
-/** @} */
 
 /** Suppress unused-variable warnings. */
 #define SILK_UNUSED(x) (void)(x)
@@ -153,26 +146,12 @@ static inline uint16_t getCurrentProcessor() noexcept
 #    error Unsupported platform
 #endif
 
-    // The rseq read matches glibc's sched_getcpu fast path. rseq_offset is meaningful only
-    // after rseq_init copied the libc ABI values into librseq's globals: rseq_size starts
-    // at -1U, becomes 0 when the libc registration failed, and is positive on success - the
-    // signed cast rejects the first two. cpu_id is negative on a thread whose rseq area is
-    // not registered (kernel sentinels for unregistered and registration-failed threads).
-    if (static_cast<int32_t>(rseq_size) > 0)
-    {
-        struct rseq * rseq = reinterpret_cast<struct rseq *>(threadPointer + rseq_offset);
-        int32_t rseqCpu = static_cast<int32_t>(rseq->cpu_id);
-
-        if (rseqCpu >= 0)
-        {
-            return static_cast<uint16_t>(rseqCpu);
-        }
-    }
-
-    // sched_getcpu is vDSO-backed on common libcs, so the fallback stays cheap. The CPU id
-    // is a sharding hint - clamping a failure to shard 0 is functionally correct.
-    int cpu = ::sched_getcpu();
-    return cpu >= 0 ? static_cast<uint16_t>(cpu) : 0;
+    // glibc's sched_getcpu fast path is THREAD_GETMEM_VOLATILE(THREAD_SELF, rseq_area.cpu_id),
+    // which is the same rseq read we do here. We skip the function call and the cpu_id >= 0
+    // fallback to vDSO/syscall - safe on any libc implementing the glibc 2.35 rseq ABI, which
+    // registers the area for every thread before it runs; initialize asserts this at startup.
+    struct rseq * rseq = reinterpret_cast<struct rseq *>(threadPointer + __rseq_offset);
+    return static_cast<uint16_t>(rseq->cpu_id);
 }
 
 /** Yield the calling thread's remaining timeslice to the OS scheduler. */


### PR DESCRIPTION
Needed for [ClickHouse/ClickHouse#109239](https://github.com/ClickHouse/ClickHouse/pull/109239), which links ClickHouse statically against a different libc and enables silk in that build. Silk does not target any specific libc. It only requires a libc that implements the glibc 2.35 rseq ABI: it exports `__rseq_offset` / `__rseq_size` / `__rseq_flags` and registers the rseq area for every thread before it runs user code. Both changes are a no-op on glibc >= 2.35.

**Dispatch strerror_r on its actual return type.** The old code picked the GNU `char *` variant of `strerror_r` when `_GNU_SOURCE` is defined. Some libcs accept `_GNU_SOURCE` but only provide the POSIX `int` variant, so the build fails (18 TUs in the ClickHouse build). Two `strerrorResult` overloads now handle whichever variant the libc provides.

**Take `__rseq_offset` from the libc, not from librseq.** When the sysroot has no `sys/rseq.h` (which declares the symbol on glibc), `getCurrentProcessor` aliased `__rseq_offset` to librseq's `rseq_offset` copy, which is only populated once `rseq_init` has run. Silk now declares the standard libc ABI symbol itself in that case and reads it directly: the value is published by the runtime libc at startup independent of any init ordering, and linking a libc that does not export the symbol fails loudly at build time instead of anything degrading at runtime. The fast-path read itself is unchanged and stays unguarded - `silk::initialize` asserts that `rseq_init` succeeded, and on any libc with this ABI every thread's area is registered before the thread runs, so a negative `cpu_id` is unreachable (the only known exception is a seccomp filter blocking `SYS_rseq` installed after startup, a configuration silk does not support).