### PR TITLE
Reject trailing characters and overflow in parseSize

### DIFF
--- a/src/perf/util/CMakeLists.txt
+++ b/src/perf/util/CMakeLists.txt
@@ -2,3 +2,7 @@ file(GLOB UTIL_SOURCES CONFIGURE_DEPENDS *.cpp)
 
 add_library(silk-perf STATIC ${UTIL_SOURCES})
 target_link_libraries(silk-perf PUBLIC silk-fibers)
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/src/perf/util/parse.cpp
+++ b/src/perf/util/parse.cpp
@@ -1,25 +1,40 @@
 #include "parse.h"
 
+#include <limits>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 uint64_t parseSize(const std::string & str)
 {
-    uint64_t n = std::stoull(str);
-    char suffix = str.empty() ? '\0' : str.back();
-    if (suffix == 'k' || suffix == 'K')
+    size_t pos;
+    uint64_t n = std::stoull(str, &pos);
+    std::string_view suffix = std::string_view(str).substr(pos);
+    uint64_t multiplier = 1;
+
+    if (suffix == "k" || suffix == "K")
     {
-        return n * 1024ULL;
+        multiplier = 1024ULL;
     }
-    if (suffix == 'm' || suffix == 'M')
+    else if (suffix == "m" || suffix == "M")
     {
-        return n * 1024ULL * 1024;
+        multiplier = 1024ULL * 1024;
     }
-    if (suffix == 'g' || suffix == 'G')
+    else if (suffix == "g" || suffix == "G")
     {
-        return n * 1024ULL * 1024 * 1024;
+        multiplier = 1024ULL * 1024 * 1024;
     }
-    return n;
+    else if (!suffix.empty())
+    {
+        throw std::invalid_argument("unknown size suffix: " + std::string(suffix));
+    }
+
+    if (n > std::numeric_limits<uint64_t>::max() / multiplier)
+    {
+        throw std::out_of_range("size is too large: " + str);
+    }
+
+    return n * multiplier;
 }
 
 uint64_t parseDuration(const std::string & str)

--- a/src/perf/util/parse.h
+++ b/src/perf/util/parse.h
@@ -6,6 +6,8 @@
 /**
  * Parse a size string with optional k/m/g suffix (case-insensitive) into bytes.
  * Examples: "4k" -> 4096, "1g" -> 1073741824, "512" -> 512.
+ * Throws std::invalid_argument on a malformed number or an unknown suffix and
+ * std::out_of_range when the result does not fit in uint64_t.
  */
 uint64_t parseSize(const std::string & str);
 

--- a/src/perf/util/tests/CMakeLists.txt
+++ b/src/perf/util/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS *.cpp)
+
+add_executable(perf-util-test ${TEST_SOURCES})
+target_link_libraries(perf-util-test PRIVATE silk-perf GTest::gtest_main)
+
+gtest_discover_tests(perf-util-test)

--- a/src/perf/util/tests/parse-test.cpp
+++ b/src/perf/util/tests/parse-test.cpp
@@ -1,0 +1,48 @@
+#include <perf/util/parse.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+
+TEST(ParseTest, SizeWithoutSuffix)
+{
+    uint64_t size = parseSize("4096");
+    ASSERT_EQ(size, 4096ULL);
+}
+
+TEST(ParseTest, SizeSuffixes)
+{
+    uint64_t kilobytes = parseSize("4k");
+    ASSERT_EQ(kilobytes, 4ULL * 1024);
+
+    uint64_t kilobytesUpper = parseSize("4K");
+    ASSERT_EQ(kilobytesUpper, 4ULL * 1024);
+
+    uint64_t megabytes = parseSize("4m");
+    ASSERT_EQ(megabytes, 4ULL * 1024 * 1024);
+
+    uint64_t megabytesUpper = parseSize("4M");
+    ASSERT_EQ(megabytesUpper, 4ULL * 1024 * 1024);
+
+    uint64_t gigabytes = parseSize("4g");
+    ASSERT_EQ(gigabytes, 4ULL * 1024 * 1024 * 1024);
+
+    uint64_t gigabytesUpper = parseSize("4G");
+    ASSERT_EQ(gigabytesUpper, 4ULL * 1024 * 1024 * 1024);
+}
+
+TEST(ParseTest, SizeRejectsTrailingCharacters)
+{
+    ASSERT_THROW(parseSize("4kb"), std::invalid_argument);
+    ASSERT_THROW(parseSize("4x"), std::invalid_argument);
+    ASSERT_THROW(parseSize("1.5m"), std::invalid_argument);
+    ASSERT_THROW(parseSize("12junk"), std::invalid_argument);
+    ASSERT_THROW(parseSize("1024wat"), std::invalid_argument);
+}
+
+TEST(ParseTest, SizeRejectsOverflow)
+{
+    ASSERT_THROW(parseSize("18446744073709551616"), std::out_of_range);
+    ASSERT_THROW(parseSize("17179869185g"), std::out_of_range);
+}


### PR DESCRIPTION
## Summary

- compare the full suffix after the number against k/m/g through a `std::string_view`, so `4kb`, `1.5m` and `12junk` throw `std::invalid_argument` instead of being silently accepted
- check the suffix multiplication against `UINT64_MAX` before it wraps and throw `std::out_of_range` (`17179869185g` used to come back as 1 GiB)
- add `perf-util-test` under `src/perf/util/tests`, guarded by `BUILD_TESTING`, covering the accepted forms and both rejections

## Test plan

- `./bb fmt --check`
- `./bb test -R '^ParseTest'`
