### PR TITLE
Fix British spelling in sharded-stack comment

### DIFF
--- a/src/util/sharded-stack.cpp
+++ b/src/util/sharded-stack.cpp
@@ -53,7 +53,7 @@ void ShardedStackBase::push(StackEntry * entry) noexcept
         if (count < batchSize)
         {
             // Prepare the link before the critical section.
-            // Release ordering publishes all writes to entry's content (e.g. deinitialisation)
+            // Release ordering publishes all writes to entry's content (e.g. deinitialization)
             // before the entry becomes visible to a concurrent pop.
             // The matching acquire is in pop after the rseq commit.
             StackEntry * oldHead = state->head.load(std::memory_order_relaxed);


### PR DESCRIPTION
Changes `deinitialisation` to `deinitialization` in the release-ordering comment in `src/util/sharded-stack.cpp`.

The codebase uses American spelling throughout (`initialization` appears 14 times, this was the sole British-spelled outlier), so this brings the comment in line with the surrounding convention. Comment-only change; no behavior impact.