### PR TITLE
Read the possible-cpu count from the kernel instead of sysconf

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -13,7 +13,7 @@ Cross-platform constants and thin OS wrappers.
 | `UNUSED(x)` | Suppresses unused-variable warnings via `(void)(x)` |
 | `PAGE_SIZE` | System page size (4096 bytes) |
 | `CACHELINE_SIZE` | Cache line size (64 bytes) |
-| `getProcessorCount()` | Number of configured CPUs (`sysconf(_SC_NPROCESSORS_CONF)`), covering offline-but-present CPUs so a raw CPU id indexes per-CPU state in bounds |
+| `getProcessorCount()` | Highest possible CPU id plus one (`/sys/devices/system/cpu/possible`), covering offline and sparse CPU ids so a raw CPU id indexes per-CPU state in bounds |
 | `getCurrentProcessor()` | Index of the CPU the calling thread is on (`sched_getcpu`) |
 | `schedYield()` | Yield the calling thread's timeslice (`sched_yield`) |
 | `cpuPause()` | CPU pause hint for spin loops |

--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -112,11 +112,11 @@ static T * containerOf(M * member, M T::* memberPtr) noexcept
     return reinterpret_cast<T *>(reinterpret_cast<uint8_t *>(member) - memberOffset(memberPtr));
 }
 
-/** Return the number of configured processors - covers offline-but-present CPUs, so a raw CPU id indexes per-CPU state in bounds. */
-static inline uint16_t getProcessorCount() noexcept
-{
-    return static_cast<uint16_t>(sysconf(_SC_NPROCESSORS_CONF));
-}
+/**
+ * Return the number of possible processors - the highest possible CPU id plus one,
+ * covering offline-but-present CPUs, so a raw CPU id indexes per-CPU state in bounds.
+ */
+uint16_t getProcessorCount() noexcept;
 
 /** Return the number of processors available to the calling process (respects taskset/cgroup affinity). */
 static inline uint16_t getAvailableProcessorCount() noexcept

--- a/src/util/platform.cpp
+++ b/src/util/platform.cpp
@@ -1,0 +1,118 @@
+#include <silk/util/platform.h>
+
+#include <silk/util/assert.h>
+#include <silk/util/scope-guard.h>
+
+#include <cerrno>
+#include <cstdlib>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace silk
+{
+
+/** Read the highest possible CPU id from the kernel's possible-cpu list and return that id plus one. */
+static uint16_t readPossibleCpuCount() noexcept
+{
+    int fd = ::open("/sys/devices/system/cpu/possible", O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+    {
+        int r = errno;
+        SILK_FAIL("could not open the possible-cpu list: r=%d", r);
+    }
+
+    SILK_SCOPE_EXIT
+    {
+        ::close(fd);
+    };
+
+    // A sysfs attribute is at most one page, so a page-sized buffer that fills
+    // up without hitting EOF means the file is malformed, not undersized.
+    char buffer[4096];
+    size_t size = 0;
+
+    for (;;)
+    {
+        ssize_t bytes = ::read(fd, buffer + size, sizeof(buffer) - 1 - size);
+
+        if (bytes > 0)
+        {
+            size += static_cast<size_t>(bytes);
+            SILK_ASSERT(size < sizeof(buffer) - 1, "the possible-cpu list is too long");
+            continue;
+        }
+
+        if (bytes == 0)
+        {
+            break;
+        }
+
+        int r = errno;
+        SILK_ASSERT(r == EINTR, "could not read the possible-cpu list: r=%d", r);
+    }
+
+    SILK_ASSERT(size, "the possible-cpu list is empty");
+    buffer[size] = '\0';
+
+    // The file holds a kernel cpu-list: comma-separated ids and ranges such as
+    // "0-15" or "0,2-4,7". Parse every element so a malformed list is rejected
+    // rather than silently truncated, and track the highest id seen.
+    unsigned long maxCpuId = 0;
+    char * position = buffer;
+
+    for (;;)
+    {
+        char * end = nullptr;
+        unsigned long firstCpuId = std::strtoul(position, &end, 10);
+
+        if (end == position || firstCpuId >= UINT16_MAX)
+        {
+            SILK_FAIL("malformed possible-cpu list '%s'", buffer);
+        }
+
+        position = end;
+        unsigned long lastCpuId = firstCpuId;
+
+        if (*position == '-')
+        {
+            ++position;
+            lastCpuId = std::strtoul(position, &end, 10);
+
+            if (end == position || lastCpuId >= UINT16_MAX || lastCpuId < firstCpuId)
+            {
+                SILK_FAIL("malformed possible-cpu list '%s'", buffer);
+            }
+
+            position = end;
+        }
+
+        if (lastCpuId > maxCpuId)
+        {
+            maxCpuId = lastCpuId;
+        }
+
+        if (*position == ',')
+        {
+            ++position;
+            continue;
+        }
+
+        if (*position && (*position != '\n' || position[1]))
+        {
+            SILK_FAIL("malformed possible-cpu list '%s'", buffer);
+        }
+
+        break;
+    }
+
+    return static_cast<uint16_t>(maxCpuId + 1);
+}
+
+uint16_t getProcessorCount() noexcept
+{
+    static const uint16_t count = readPossibleCpuCount();
+    return count;
+}
+
+} // namespace silk


### PR DESCRIPTION
Related to https://github.com/ClickHouse/ClickHouse/pull/109239.

`getProcessorCount` must return the highest possible CPU id plus one, so that raw CPU ids (as returned by `getCurrentProcessor`) index per-CPU state in bounds. It was implemented as `sysconf(_SC_NPROCESSORS_CONF)`, which is not portable across libcs:

- glibc parses `/sys/devices/system/cpu/possible` and only falls back to /proc/stat and the affinity mask (`sysdeps/unix/sysv/linux/getsysstats.c`).
- musl derives the value from the calling thread's affinity mask (`sched_getaffinity`), so a thread pinned to CPU `n` reports one processor while raw CPU ids still range up to n. This made `FiberScheduler::initialize` find no active CPU and abort under `taskset`.

Replace the `sysconf` call with reading the highest CPU id from the kernel's possible-cpu list (`/sys/devices/system/cpu/possible`) directly — the same source glibc uses — and fail loudly if the list is unreadable or malformed. The result is computed once and cached. `getAvailableProcessorCount` is unchanged and still respects affinity, which is its documented purpose.