### PR TITLE
Fix British spelling in util comments and doc

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -87,7 +87,7 @@ while (list) {
 
 ## ShardedStack (`sharded-stack.h`)
 
-Per-CPU intrusive LIFO stack backed by restartable sequences (rseq). The fast path (push/pop when the per-CPU list is non-empty/non-full) executes zero atomic instructions. The kernel aborts and restarts the rseq critical section on preemption or migration, so plain loads/stores suffice for per-CPU state. The slow path transfers a full batch to/from a global pool via a single 128-bit CAS, amortising its cost over `batchSize` operations.
+Per-CPU intrusive LIFO stack backed by restartable sequences (rseq). The fast path (push/pop when the per-CPU list is non-empty/non-full) executes zero atomic instructions. The kernel aborts and restarts the rseq critical section on preemption or migration, so plain loads/stores suffice for per-CPU state. The slow path transfers a full batch to/from a global pool via a single 128-bit CAS, amortizing its cost over `batchSize` operations.
 
 Objects must embed a `StackEntry` member; the typed wrapper `ShardedStack` takes a member pointer as a template argument.
 

--- a/include/silk/util/platform.h
+++ b/include/silk/util/platform.h
@@ -161,7 +161,7 @@ static inline void schedYield() noexcept
 }
 
 /**
- * Emit a CPU pause hint to reduce power and improve pipeline behaviour in spin loops.
+ * Emit a CPU pause hint to reduce power and improve pipeline behavior in spin loops.
  *
  * On aarch64 we use ISB rather than YIELD. YIELD is a NOP on non-SMT cores
  * (which includes all Graviton generations), so it provides no backoff at all.

--- a/include/silk/util/sharded-stack.h
+++ b/include/silk/util/sharded-stack.h
@@ -20,7 +20,7 @@ namespace silk
  *
  * Each CPU holds a single linked list. When the list empties on pop, or fills on
  * push, a single 128-bit CAS transfers a batch to/from the global
- * fullFreeLists/emptyFreeLists pool, amortising its cost over batchSize operations.
+ * fullFreeLists/emptyFreeLists pool, amortizing its cost over batchSize operations.
  *
  * Objects are intrusive: each element must embed a StackEntry. Use the typed
  * wrapper ShardedStack instead of this class directly.


### PR DESCRIPTION
Changes `amortising` -> `amortizing` in the sharded-stack comment and util doc, and `behaviour` -> `behavior` in the platform pause-hint comment, to match the American spelling used throughout the codebase (following b3d129c).

Comment/doc-only change; no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)