### PR TITLE
Unshallow the checkout before rebuilding clickhouse-public

### DIFF
--- a/ci/jobs/rebuild_clickhouse_public.py
+++ b/ci/jobs/rebuild_clickhouse_public.py
@@ -95,10 +95,12 @@ def _report_conflict(sha):
 
 def rebuild():
     sha = Info().sha
+    shallow = Shell.get_output("git rev-parse --is-shallow-repository") == "true"
+    unshallow = "--unshallow " if shallow else ""
     if not Shell.check(
         'git config user.name "clickhouse-robot-gh"'
         ' && git config user.email "clickhouse-robot-gh@users.noreply.github.com"'
-        f" && git fetch origin main {BRANCH}"
+        f" && git fetch {unshallow}origin main {BRANCH}"
         f" && git checkout -B {BRANCH} origin/{BRANCH}~1",
         verbose=True,
     ):


### PR DESCRIPTION
The Praktika checkout is shallow, so the rebase in the rebuild job saw no common ancestor and conflicted on every file (add/add). Fetch with `--unshallow` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)