### PR TITLE
Reject duration conversion overflow

### DIFF
--- a/src/perf/util/parse.cpp
+++ b/src/perf/util/parse.cpp
@@ -41,32 +41,40 @@ uint64_t parseDuration(const std::string & str)
 {
     size_t pos;
     uint64_t n = std::stoull(str, &pos);
-    std::string suffix = str.substr(pos);
-    if (suffix == "ns")
+    std::string_view suffix = std::string_view(str).substr(pos);
+    uint64_t multiplier = 1;
+
+    if (suffix.empty() || suffix == "s")
     {
-        return n;
+        multiplier = 1'000'000'000ULL;
     }
-    if (suffix.empty())
+    else if (suffix == "ns")
     {
-        return n * 1'000'000'000ULL;
+        multiplier = 1;
     }
-    if (suffix == "us")
+    else if (suffix == "us")
     {
-        return n * 1'000ULL;
+        multiplier = 1'000ULL;
     }
-    if (suffix == "ms")
+    else if (suffix == "ms")
     {
-        return n * 1'000'000ULL;
+        multiplier = 1'000'000ULL;
     }
-    if (suffix == "s")
+    else if (suffix == "m")
     {
-        return n * 1'000'000'000ULL;
+        multiplier = 60'000'000'000ULL;
     }
-    if (suffix == "m")
+    else
     {
-        return n * 60'000'000'000ULL;
+        throw std::invalid_argument("unknown duration suffix: " + std::string(suffix));
     }
-    throw std::invalid_argument("unknown duration suffix: " + suffix);
+
+    if (n > std::numeric_limits<uint64_t>::max() / multiplier)
+    {
+        throw std::out_of_range("duration is too large: " + str);
+    }
+
+    return n * multiplier;
 }
 
 std::string formatDuration(uint64_t ns)

--- a/src/perf/util/parse.h
+++ b/src/perf/util/parse.h
@@ -15,6 +15,8 @@ uint64_t parseSize(const std::string & str);
  * Parse a duration string with an optional unit suffix into nanoseconds.
  * Supported units: ns, us, ms, s, m. No suffix is treated as seconds.
  * Examples: "10" -> 10000000000, "100us" -> 100000, "1ms" -> 1000000.
+ * Throws std::invalid_argument on a malformed number or an unknown suffix and
+ * std::out_of_range when the result does not fit in uint64_t.
  */
 uint64_t parseDuration(const std::string & str);
 

--- a/src/perf/util/tests/parse-test.cpp
+++ b/src/perf/util/tests/parse-test.cpp
@@ -59,7 +59,21 @@ TEST(ParseTest, DurationSuffixes)
 
 TEST(ParseTest, DurationRejectsOverflow)
 {
+    ASSERT_EQ(parseDuration("18446744073709551615ns"), 18'446'744'073'709'551'615ULL);
+    ASSERT_THROW(parseDuration("18446744073709551616ns"), std::out_of_range);
+
+    ASSERT_EQ(parseDuration("18446744073709551us"), 18'446'744'073'709'551'000ULL);
+    ASSERT_THROW(parseDuration("18446744073709552us"), std::out_of_range);
+
+    ASSERT_EQ(parseDuration("18446744073709ms"), 18'446'744'073'709'000'000ULL);
+    ASSERT_THROW(parseDuration("18446744073710ms"), std::out_of_range);
+
+    ASSERT_EQ(parseDuration("18446744073"), 18'446'744'073'000'000'000ULL);
+    ASSERT_THROW(parseDuration("18446744074"), std::out_of_range);
+
     ASSERT_EQ(parseDuration("18446744073s"), 18'446'744'073'000'000'000ULL);
     ASSERT_THROW(parseDuration("18446744074s"), std::out_of_range);
+
+    ASSERT_EQ(parseDuration("307445734m"), 18'446'744'040'000'000'000ULL);
     ASSERT_THROW(parseDuration("307445735m"), std::out_of_range);
 }

--- a/src/perf/util/tests/parse-test.cpp
+++ b/src/perf/util/tests/parse-test.cpp
@@ -46,3 +46,20 @@ TEST(ParseTest, SizeRejectsOverflow)
     ASSERT_THROW(parseSize("18446744073709551616"), std::out_of_range);
     ASSERT_THROW(parseSize("17179869185g"), std::out_of_range);
 }
+
+TEST(ParseTest, DurationSuffixes)
+{
+    ASSERT_EQ(parseDuration("10"), 10'000'000'000ULL);
+    ASSERT_EQ(parseDuration("10ns"), 10ULL);
+    ASSERT_EQ(parseDuration("10us"), 10'000ULL);
+    ASSERT_EQ(parseDuration("10ms"), 10'000'000ULL);
+    ASSERT_EQ(parseDuration("10s"), 10'000'000'000ULL);
+    ASSERT_EQ(parseDuration("10m"), 600'000'000'000ULL);
+}
+
+TEST(ParseTest, DurationRejectsOverflow)
+{
+    ASSERT_EQ(parseDuration("18446744073s"), 18'446'744'073'000'000'000ULL);
+    ASSERT_THROW(parseDuration("18446744074s"), std::out_of_range);
+    ASSERT_THROW(parseDuration("307445735m"), std::out_of_range);
+}


### PR DESCRIPTION
## Summary

- **Check duration unit conversion before multiplying.**
- Reject values that do not fit in `uint64_t` instead of silently wrapping.
- Add maximum-boundary and overflow coverage to `perf-util-test`.

## Why

`parseDuration()` is shared by the perf tools and simulator. Values such as `18446744074s` fit in the parsed integer but overflow when converted to nanoseconds, producing a smaller unrelated duration.

This follows the checked-multiplier pattern already used by `parseSize()`.

## Test plan

- `./bb fmt --check`
- `ParseTest.*` targeted suite