### PR TITLE
Reject oversized stall durations

### DIFF
--- a/src/perf/net-perf-asio.cpp
+++ b/src/perf/net-perf-asio.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <list>
 #include <memory>
@@ -211,7 +212,7 @@ struct ClientConfig
     uint64_t durationNs = 10'000'000'000ULL;
     uint64_t warmupNs = 2'000'000'000ULL;
     double stallRateHz = 0.0;
-    uint64_t stallNs = 0;
+    uint32_t stallNs = 0;
     bool printCounters = false;
 };
 
@@ -483,13 +484,13 @@ static void runClient(int argc, char ** argv)
         }
         cfg.durationNs = parseDuration(durationStr);
         cfg.warmupNs = parseDuration(warmupStr);
-        cfg.stallNs = parseDuration(stallDurationStr);
+        cfg.stallNs = parseStallDuration(stallDurationStr);
         if (verbose)
         {
             silk::Logger::setLevel(silk::LogLevel::DEBUG);
         }
     }
-    catch (const cxxopts::exceptions::exception & ex)
+    catch (const std::exception & ex)
     {
         std::cerr << "error: " << ex.what() << "\n" << cli.help() << "\n";
         exit(1);

--- a/src/perf/net-perf-epoll.cpp
+++ b/src/perf/net-perf-epoll.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -839,7 +840,7 @@ struct ClientConfig
     uint64_t durationNs = 10'000'000'000ULL;
     uint64_t warmupNs = 2'000'000'000ULL;
     double stallRateHz = 0.0;
-    uint64_t stallNs = 0;
+    uint32_t stallNs = 0;
     bool printCounters = false;
 };
 
@@ -1281,7 +1282,7 @@ static void runClient(int argc, char ** argv)
         }
         cfg.durationNs = parseDuration(durationStr);
         cfg.warmupNs = parseDuration(warmupStr);
-        cfg.stallNs = parseDuration(stallDurationStr);
+        cfg.stallNs = parseStallDuration(stallDurationStr);
         if (cfg.threads == 0)
         {
             cfg.threads = silk::getAvailableProcessorCount();
@@ -1295,7 +1296,7 @@ static void runClient(int argc, char ** argv)
             silk::Logger::setLevel(silk::LogLevel::DEBUG);
         }
     }
-    catch (const cxxopts::exceptions::exception & ex)
+    catch (const std::exception & ex)
     {
         std::cerr << "error: " << ex.what() << "\n" << cli.help() << "\n";
         exit(1);

--- a/src/perf/net-perf.cpp
+++ b/src/perf/net-perf.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -527,7 +528,7 @@ struct ClientConfig
     // The first 4 bytes of each message are the stall duration in nanoseconds;
     // server busy-loops for that long before echoing.
     double stallRateHz = 0.0;
-    uint64_t stallNs = 0;
+    uint32_t stallNs = 0;
     bool printCounters = false;
 };
 
@@ -806,13 +807,13 @@ static void runClient(int argc, char ** argv)
         }
         cfg.durationNs = parseDuration(durationStr);
         cfg.warmupNs = parseDuration(warmupStr);
-        cfg.stallNs = parseDuration(stallDurationStr);
+        cfg.stallNs = parseStallDuration(stallDurationStr);
         if (verbose)
         {
             silk::Logger::setLevel(silk::LogLevel::DEBUG);
         }
     }
-    catch (const cxxopts::exceptions::exception & ex)
+    catch (const std::exception & ex)
     {
         std::cerr << "error: " << ex.what() << "\n" << cli.help() << "\n";
         exit(1);

--- a/src/perf/util/stall.cpp
+++ b/src/perf/util/stall.cpp
@@ -13,7 +13,7 @@ uint32_t parseStallDuration(const std::string & str)
     uint64_t ns = parseDuration(str);
     if (ns > UINT32_MAX)
     {
-        throw std::out_of_range("stall duration is too large: " + str);
+        throw std::out_of_range("stall duration exceeds " + std::to_string(UINT32_MAX) + "ns: " + str);
     }
     return static_cast<uint32_t>(ns);
 }
@@ -32,7 +32,7 @@ uint32_t StallScheduler::next() noexcept
     std::exponential_distribution<double> dist(rateHz);
     double gapNs = dist(rng) * 1'000'000'000.0;
     nextStallCycles = now + silk::Tsc::nanosecondsToCycles(static_cast<uint64_t>(gapNs));
-    return static_cast<uint32_t>(stallNs);
+    return stallNs;
 }
 
 void busyLoopForStall(const char * buf) noexcept

--- a/src/perf/util/stall.cpp
+++ b/src/perf/util/stall.cpp
@@ -1,10 +1,22 @@
 #include "stall.h"
 
+#include <perf/util/parse.h>
 #include <silk/util/platform.h>
 #include <silk/util/tsc.h>
 
 #include <cstring>
 #include <random>
+#include <stdexcept>
+
+uint32_t parseStallDuration(const std::string & str)
+{
+    uint64_t ns = parseDuration(str);
+    if (ns > UINT32_MAX)
+    {
+        throw std::out_of_range("stall duration is too large: " + str);
+    }
+    return static_cast<uint32_t>(ns);
+}
 
 uint32_t StallScheduler::next() noexcept
 {

--- a/src/perf/util/stall.h
+++ b/src/perf/util/stall.h
@@ -2,6 +2,10 @@
 
 #include <cstdint>
 #include <random>
+#include <string>
+
+/** Parse a stall duration that fits in the uint32_t wire field. */
+uint32_t parseStallDuration(const std::string & str);
 
 /**
  * Per-connection Poisson scheduler for stall messages in net-perf workloads.
@@ -21,7 +25,7 @@ public:
      * constructor so the caller's first call to next() returns 0 (no stall on
      * the first message). rateHz = 0 leaves the scheduler disabled.
      */
-    StallScheduler(double rateHz_, uint64_t stallNs_, uint64_t seed) noexcept
+    StallScheduler(double rateHz_, uint32_t stallNs_, uint64_t seed) noexcept
         : rateHz(rateHz_)
         , stallNs(stallNs_)
         , rng(seed)
@@ -39,7 +43,7 @@ public:
 
 private:
     double rateHz = 0.0;
-    uint64_t stallNs = 0;
+    uint32_t stallNs = 0;
     std::mt19937_64 rng;
     uint64_t nextStallCycles = 0;
 };

--- a/src/perf/util/tests/stall-test.cpp
+++ b/src/perf/util/tests/stall-test.cpp
@@ -11,6 +11,18 @@ TEST(StallTest, ParsesDurationsWithinWireRange)
     ASSERT_EQ(parseStallDuration("4294967295ns"), UINT32_MAX);
 }
 
+TEST(StallTest, ParsesZeroDuration)
+{
+    ASSERT_EQ(parseStallDuration("0"), 0U);
+    ASSERT_EQ(parseStallDuration("0ns"), 0U);
+}
+
+TEST(StallTest, ChecksDurationsWithoutSuffix)
+{
+    ASSERT_EQ(parseStallDuration("4"), 4'000'000'000U);
+    ASSERT_THROW(parseStallDuration("5"), std::out_of_range);
+}
+
 TEST(StallTest, RejectsDurationsOutsideWireRange)
 {
     ASSERT_THROW(parseStallDuration("4294967296ns"), std::out_of_range);

--- a/src/perf/util/tests/stall-test.cpp
+++ b/src/perf/util/tests/stall-test.cpp
@@ -1,0 +1,18 @@
+#include <perf/util/stall.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+
+TEST(StallTest, ParsesDurationsWithinWireRange)
+{
+    ASSERT_EQ(parseStallDuration("1ms"), 1'000'000U);
+    ASSERT_EQ(parseStallDuration("4294967295ns"), UINT32_MAX);
+}
+
+TEST(StallTest, RejectsDurationsOutsideWireRange)
+{
+    ASSERT_THROW(parseStallDuration("4294967296ns"), std::out_of_range);
+    ASSERT_THROW(parseStallDuration("5s"), std::out_of_range);
+}


### PR DESCRIPTION
## Summary

- **Reject stall durations above `UINT32_MAX`.**
- Keep the configured stall duration as `uint32_t` after validation.
- Use one checked parser for all three net-perf clients.
- Add coverage for the maximum value and the first overflowing values.

## Why

The stall wire format stores `stall_ns` in the first four bytes as a `uint32_t`. `--stall-duration 5s` used to become `705032704ns` after narrowing, and `4294967296ns` became `0ns`.

The client now reports an error before starting the benchmark instead of silently changing the requested workload.

## Test plan

- `./bb fmt --check`
- `StallTest.*` targeted suite
- Follow-up to #149